### PR TITLE
Thealmarty/fix set type checker

### DIFF
--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -222,8 +222,8 @@ cType ii _g (Star n) ann = do
         (n < j)
         (throwError $
          show (Star n) ++
-         " is of type * m where m > n. But the input type" ++
-         showVal (snd ann) ++ " is of type * of a lower universe.")
+         " is of type * of a higher universe. But the input type " ++
+         showVal (snd ann) ++ " is of type * of a equal or lower universe.")
     _ ->
       throwError $
       "* n is of type * but " ++ showVal (snd ann) ++ " is not of type *."

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -213,10 +213,20 @@ usageCompare Omega pi    = True --actual usage can be any when required usage is
 --checker for checkable terms checks the term against an annotation and returns ().
 cType ∷ Natural → Context → CTerm → Annotation → Result ()
 -- *
-cType ii _g (Star n) ann =
-  unless -- TODO i only needs to be < j in typing rule?
-    (SNat 0 == fst ann && quote0 (snd ann) == Star (n + 1))
-    (throwError (errorMsg ii (Star n) (0, VStar (n + 1)) ann))
+cType ii _g (Star n) ann = do
+  unless (SNat 0 == fst ann) (throwError "Sigma has to be 0.") -- checks sigma = 0.
+  let ty = snd ann
+  case ty of
+    VStar j ->
+      unless
+        (n < j)
+        (throwError $
+         show (Star n) ++
+         " is of type * m where m > n. But the input type" ++
+         showVal (snd ann) ++ " is of type * of a lower universe.")
+    _ ->
+      throwError $
+      "* n is of type * but " ++ showVal (snd ann) ++ " is not of type *."
 cType ii _g Nats ann =
   unless
     (SNat 0 == fst ann && quote0 (snd ann) == Star 0)

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -225,8 +225,7 @@ cType ii _g (Star n) ann = do
          " is of type * of a higher universe. But the input type " ++
          showVal (snd ann) ++ " is of type * of a equal or lower universe.")
     _ ->
-      throwError $
-      "* n is of type * but " ++ showVal (snd ann) ++ " is not of type *."
+      throwError $ "* n is of type * but " ++ showVal (snd ann) ++ " is not *."
 cType ii _g Nats ann =
   unless
     (SNat 0 == fst ann && quote0 (snd ann) == Star 0)

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -223,7 +223,7 @@ cType ii _g (Star n) ann = do
         (throwError $
          show (Star n) ++
          " is of type * of a higher universe. But the input type " ++
-         showVal (snd ann) ++ " is of type * of a equal or lower universe.")
+         showVal (snd ann) ++ " is * of a equal or lower universe.")
     _ ->
       throwError $ "* n is of type * but " ++ showVal (snd ann) ++ " is not *."
 cType ii _g Nats ann =


### PR DESCRIPTION
With minimal testing:
~~~~
*Juvix.Core.MainLang> cType 0 [] (Star 0) (0,VStar 0)
Left "Star 0 is of type * of a higher universe. But the input type *0 is * of a equal or lower universe."
*Juvix.Core.MainLang> cType 0 [] (Star 0) (1,VStar 0)
Left "Sigma has to be 0."
*Juvix.Core.MainLang> cType 0 [] (Star 0) (0,VStar 1)
Right ()
*Juvix.Core.MainLang> cType 0 [] (Star 0) (0,VStar 3)
Right ()
*Juvix.Core.MainLang> cType 0 [] (Star 0) (0,VNats)
Left "* n is of type * but Nats is not *."
~~~~