### PR TITLE
The error msgs now more consistently show users the names they are familiar with (as per the parser and lang ref).

### DIFF
--- a/doc/reference/language-reference.pdf
+++ b/doc/reference/language-reference.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de41290c9dd2f07605318ec20ad49672381de64e9c26b6af4acb339691d73aeb
-size 232510
+oid sha256:ad0726380b8d28e18efd508ed6f160649abc1096f773d1db39ebae475150337d
+size 232378

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -234,7 +234,7 @@ cType _ii _g (Star n) ann = do
         (n < j)
         (throwError $
          show (Star n) ++
-         " is of type * of a higher universe. But the input type " ++
+         " is of type * of a higher universe. But the expected type " ++
          showVal (snd ann) ++ " is * of a equal or lower universe.")
     _ ->
       throwError $ "* n is of type * but " ++ showVal (snd ann) ++ " is not *."

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -47,14 +47,15 @@ data CTerm
   deriving (Eq)
 
 instance Show CTerm where
-  show (Star n) = "*" ++ show n
-  show Nats = "Nat"
-  show (Pi _usage varTy resultTy) = "[Π]" ++ show varTy ++ "->" ++ show resultTy
+  show (Star n) = "* " ++ show n
+  show Nats = "Nat "
+  show (Pi _usage varTy resultTy) =
+    "[Π] " ++ show varTy ++ "-> " ++ show resultTy
   show (Pm _usage first second) =
-    "([π]" ++ show first ++ "," ++ show second ++ ")"
-  show (Pa _usage first second) = "/\\" ++ show first ++ show second
-  show (NPm first second) = "\\/" ++ show first ++ show second
-  show (Lam var) = "\\" ++ show var
+    "([π] " ++ show first ++ "," ++ show second ++ ") "
+  show (Pa _usage first second) = "/\\ " ++ show first ++ show second
+  show (NPm first second) = "\\/ " ++ show first ++ show second
+  show (Lam var) = "\\ " ++ show var
   show (Conv term) --Conv should be invisible to users.
    = show term
 

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -52,7 +52,7 @@ instance Show CTerm where
   show (Pi _usage varTy resultTy) =
     "[Π] " ++ show varTy ++ "-> " ++ show resultTy
   show (Pm _usage first second) =
-    "([π] " ++ show first ++ "," ++ show second ++ ") "
+    "([π] " ++ show first ++ ", " ++ show second ++ ") "
   show (Pa _usage first second) = "/\\ " ++ show first ++ show second
   show (NPm first second) = "\\/ " ++ show first ++ show second
   show (Lam var) = "\\ " ++ show var
@@ -89,13 +89,13 @@ data Value
 
 showVal ∷ Value → String
 showVal (VLam f) = showFun f
-showVal (VStar i) = "*" ++ show i
-showVal VNats = "Nats"
-showVal (VPi n v f) = "[" ++ show n ++ "]" ++ showVal v ++ " -> " ++ showFun f
+showVal (VStar i) = "* " ++ show i
+showVal VNats = "Nats "
+showVal (VPi n v f) = "[" ++ show n ++ "] " ++ showVal v ++ " -> " ++ showFun f
 showVal (VPm n v f) =
-  "([" ++ show n ++ "]" ++ showVal v ++ ", " ++ showFun f ++ ")"
-showVal (VPa _ _ _) = "/\\"
-showVal (VNPm _ _) = "\\/"
+  "([" ++ show n ++ "] " ++ showVal v ++ ", " ++ showFun f ++ ") "
+showVal (VPa _ _ _) = "/\\ "
+showVal (VNPm _ _) = "\\/ "
 showVal (VNeutral _n) = "neutral "
 showVal (VNat i) = show i
 

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -44,7 +44,19 @@ data CTerm
                         -- The abstracted variable's usage is tracked with the Usage(π).
   | Conv ITerm --(CONV) conversion rule. TODO make sure 0Γ ⊢ S≡T
               -- Conv is the constructor that embeds ITerm to CTerm
-  deriving (Show, Eq)
+  deriving (Eq)
+
+instance Show CTerm where
+  show (Star n) = "*" ++ show n
+  show Nats = "Nat"
+  show (Pi _usage varTy resultTy) = "[Π]" ++ show varTy ++ "->" ++ show resultTy
+  show (Pm _usage first second) =
+    "([π]" ++ show first ++ "," ++ show second ++ ")"
+  show (Pa _usage first second) = "/\\" ++ show first ++ show second
+  show (NPm first second) = "\\/" ++ show first ++ show second
+  show (Lam var) = "\\" ++ show var
+  show (Conv term) --Conv should be invisible to users.
+   = show term
 
 -- inferable terms
 data ITerm
@@ -208,12 +220,12 @@ type Result a = Either String a --when type checking fails, it throws an error.
 usageCompare ∷ Usage → Usage → Bool
 usageCompare (SNat 0) pi = pi == SNat 0 || pi == Omega
 usageCompare (SNat i) pi = pi == SNat i || pi == Omega
-usageCompare Omega pi    = True --actual usage can be any when required usage is unspecified.
+usageCompare Omega _pi   = True --actual usage can be any when required usage is unspecified.
 
 --checker for checkable terms checks the term against an annotation and returns ().
 cType ∷ Natural → Context → CTerm → Annotation → Result ()
 -- *
-cType ii _g (Star n) ann = do
+cType _ii _g (Star n) ann = do
   unless (SNat 0 == fst ann) (throwError "Sigma has to be 0.") -- checks sigma = 0.
   let ty = snd ann
   case ty of

--- a/src/Juvix/Core/Parser.hs
+++ b/src/Juvix/Core/Parser.hs
@@ -22,7 +22,7 @@ languageDef =
         , "[π]" --dependent multiplicative conjunction type
         , "/\\" --dependent additive conjunction type
         , "\\/" --non-dependent multiplicative disjunction type
-        , "Bound" --Bound var
+        , "\\" --Bound var
         , "Free"
         , "Local"
         , "Quote"
@@ -114,7 +114,7 @@ convTerm = do
 
 boundTerm ∷ Parser ITerm
 boundTerm = do
-  reserved "Bound"
+  reserved "\\"
   index <- natural
   return $ Bound (fromInteger index)
 


### PR DESCRIPTION
Minimally Tested:
~~~~
*Juvix.Core.MainLang> cType 0 [] (Star 1) (0,VStar 0)
Left "*1 is of type * of a higher universe. But the expected type *0 is * of a equal or lower universe."
*Juvix.Core.MainLang> cType 0 [] (Pi 0 Nats Nats) (0, VStar 0)
Right ()
*Juvix.Core.MainLang> cType 0 [] (Pi 1 Nats Nats) (0, VStar 0)
Right ()
*Juvix.Core.MainLang> cType 0 [] (Pi 1 Nats Nats) (1, VStar 0)
Left "Sigma has to be 0."
*Juvix.Core.MainLang> cType 0 [] (Pi 1 Nats Nats) (0, VStar 1)
Left "Type mismatched. \nNat \n (binder number 0) is of type \n\"*1\" , with 0 usage.\n But the expected type is \"*0\" , with 0 usage."
*Juvix.Core.MainLang> cType 0 [] (Pi 1 Nats Nats) (0, VNats)
Left "The variable type and the result type must be of type * at the same level."
~~~~