### PR TITLE
Improve Lam type checker

### DIFF
--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -100,7 +100,7 @@ showVal (VNeutral _n) = "neutral "
 showVal (VNat i) = show i
 
 showFun ∷ (Value → Value) → String
-showFun _f = "\\x.t"
+showFun _f = "\\x.t "
 
 --A neutral term is either a variable or an application of a neutral term to a value
 data Neutral
@@ -265,7 +265,8 @@ cType ii g (NPm first second) ann = undefined
 -- (Lam) introduction rule of dependent function type
 cType ii g (Lam s) ann =
   case ann of
-    (sig, VPi pi ty ty') -> do
+    (sig, VPi pi ty ty') --Lam s should be of dependent function type (Pi pi ty ty').
+     -> do
       let sVal = cEval s []
       cType
         (ii + 1)


### PR DESCRIPTION
Instead of throwing the more generic error, (as in L283 after this commit), it throws the more specific error that the input type is not a dependent function type.

Test results: 
~~~~
*Juvix.Core.MainLang> cType 0 [] (Lam Nats) (1, VPi 1 VNats (VNPm VNats))
Left "Type mismatched. \nNat  \n (binder number 1) is of type \n\"\\\\/ \" , with 1 usage.\n But the expected type is \"* 0\" , with 0 usage."
*Juvix.Core.MainLang> cType 0 [] (Lam Nats) (1,VNats)
Left "Nats  is not a function type but should be."
~~~~