### PR TITLE
Mariari/text symbol

### DIFF
--- a/src/Juvix/Bohm/Default.hs
+++ b/src/Juvix/Bohm/Default.hs
@@ -61,22 +61,22 @@ and' = onBool (&&)
 or' ∷ Primitive → Primitive → Maybe Primitive
 or' = onBool (||)
 
-defaultEnv ∷ Map SomeSymbol BT.Fn
+defaultEnv ∷ Map Symbol BT.Fn
 defaultEnv =
   Map.fromList
-    [ (someSymbolVal "plus", BT.Arg2 plus)
-    , (someSymbolVal "+", BT.Arg2 plus)
-    , (someSymbolVal "*", BT.Arg2 times)
-    , (someSymbolVal "-", BT.Arg2 minus)
-    , (someSymbolVal "<>", BT.Arg2 neq)
-    , (someSymbolVal "<", BT.Arg2 lt)
-    , (someSymbolVal ">", BT.Arg2 gt)
-    , (someSymbolVal "<=", BT.Arg2 le)
-    , (someSymbolVal ">=", BT.Arg2 ge)
-    , (someSymbolVal "==", BT.Arg2 eq)
-    , (someSymbolVal "and", BT.Arg2 and')
-    , (someSymbolVal "or", BT.Arg2 or')
-    , (someSymbolVal "mod", BT.Arg2 mod')
+    [ (intern "plus", BT.Arg2 plus)
+    , (intern "+", BT.Arg2 plus)
+    , (intern "*", BT.Arg2 times)
+    , (intern "-", BT.Arg2 minus)
+    , (intern "<>", BT.Arg2 neq)
+    , (intern "<", BT.Arg2 lt)
+    , (intern ">", BT.Arg2 gt)
+    , (intern "<=", BT.Arg2 le)
+    , (intern ">=", BT.Arg2 ge)
+    , (intern "==", BT.Arg2 eq)
+    , (intern "and", BT.Arg2 and')
+    , (intern "or", BT.Arg2 or')
+    , (intern "mod", BT.Arg2 mod')
     ]
 
 defaultSymbols ∷ [Precedence]

--- a/src/Juvix/Bohm/Parser.hs
+++ b/src/Juvix/Bohm/Parser.hs
@@ -74,11 +74,11 @@ brackets   = T.brackets   lexer
 natural    = T.natural    lexer
 operator'  = T.operator   lexer
 
-operator ∷ Stream s m Char ⇒ ParsecT s u m SomeSymbol
-operator = someSymbolVal <$> operator'
+operator ∷ Stream s m Char ⇒ ParsecT s u m Symbol
+operator = intern <$> operator'
 
-symbol ∷ Stream s m Char ⇒ ParsecT s u m SomeSymbol
-symbol = someSymbolVal <$> identifier
+symbol ∷ Stream s m Char ⇒ ParsecT s u m Symbol
+symbol = intern <$> identifier
 
 -- Grammar ---------------------------------------------------------------------
 
@@ -115,7 +115,7 @@ expression' =  ifThenElse
 
 -- Infix Parser ----------------------------------------------------------------
 
-createInfixUnkown ∷ SomeSymbol → Bohm → Bohm → Bohm
+createInfixUnkown ∷ Symbol → Bohm → Bohm → Bohm
 createInfixUnkown sym arg1 arg2 = Application (Application (Symbol' sym) arg1) arg2
 
 -- special cased and and or!
@@ -124,7 +124,7 @@ precedenceToOps =
   (\(Precedence _ s a) →
      if | s == "or"  → E.Infix (Or  <$ reservedOp s) a
         | s == "and" → E.Infix (And <$ reservedOp s) a
-        | otherwise  → E.Infix (createInfixUnkown (someSymbolVal s) <$ reservedOp s) a)
+        | otherwise  → E.Infix (createInfixUnkown (intern s) <$ reservedOp s) a)
   <<$>>
     groupBy (\x y -> level x == level y)
             (reverse (sortOn level defaultSymbols))

--- a/src/Juvix/Bohm/Translation.hs
+++ b/src/Juvix/Bohm/Translation.hs
@@ -15,14 +15,14 @@ import           Juvix.NodeInterface
 
 data Env net = Env { level :: Int
                    , net'  :: net B.Lang
-                   , free  :: Map SomeSymbol (Node, PortType)
+                   , free  :: Map Symbol (Node, PortType)
                    } deriving (Generic)
 
 newtype EnvState net a = EnvS (State (Env net) a)
   deriving (Functor, Applicative, Monad)
   deriving (HasState "level" Int) via
     Rename "level" (Field "level" () (MonadState (State (Env net))))
-  deriving (HasState "free" (Map SomeSymbol (Node, PortType))) via
+  deriving (HasState "free" (Map Symbol (Node, PortType))) via
     (Field "free" () (MonadState (State (Env net))))
   deriving (HasState "net" (net B.Lang)) via
     Rename "net'" (Field "net'" () (MonadState (State (Env net))))
@@ -33,7 +33,7 @@ execEnvState (EnvS m) = execState m
 evalEnvState ∷ Network net ⇒ EnvState net a → Env net → a
 evalEnvState (EnvS m) = evalState m
 
-astToNet ∷ Network net ⇒ BT.Bohm → Map.Map SomeSymbol BT.Fn → net B.Lang
+astToNet ∷ Network net ⇒ BT.Bohm → Map.Map Symbol BT.Fn → net B.Lang
 astToNet bohm customSymMap = net'
   where
     Env {net'} = execEnvState (recursive bohm Map.empty) (Env 0 empty mempty)
@@ -392,10 +392,10 @@ chaseAndCreateFan (num,port) = do
 
 
 -- | numToSymbol generates a symbol from a number
-numToSymbol ∷ Int → SomeSymbol
+numToSymbol ∷ Int → Symbol
 numToSymbol x
-  | x < 26    = someSymbolVal (return ((['x'..'z'] <> ['a'..'w']) !! x))
-  | otherwise = someSymbolVal ("%gen" <> show x)
+  | x < 26    = intern (return ((['x'..'z'] <> ['a'..'w']) !! x))
+  | otherwise = intern ("%gen" <> show x)
 
 
 -- | generate a new number based on the map size

--- a/src/Juvix/Bohm/Type.hs
+++ b/src/Juvix/Bohm/Type.hs
@@ -6,13 +6,13 @@ import           Juvix.Library
 -- TODO:: Investigate if it would be advantageous to promote this to a well typed gadt
 data Bohm
   = IntLit Int
-  | Lambda SomeSymbol Bohm
+  | Lambda Symbol Bohm
   | Application Bohm Bohm
   | Not Bohm
   | True'
   | False'
-  | Letrec SomeSymbol Bohm
-  | Let SomeSymbol Bohm Bohm
+  | Letrec Symbol Bohm
+  | Let Symbol Bohm Bohm
   | If Bohm Bohm Bohm
   | Cons Bohm Bohm
   | Or Bohm Bohm
@@ -21,7 +21,7 @@ data Bohm
   | Car Bohm
   | Cdr Bohm
   | IsNil Bohm
-  | Symbol' SomeSymbol
+  | Symbol' Symbol
   -- Not valid syntax but for read back of a graph
   | Erase
   -- Not valid syntax but for read back of a graph

--- a/src/Juvix/Core/Erasure.hs
+++ b/src/Juvix/Core/Erasure.hs
@@ -36,30 +36,33 @@ erase term =
           pure (EAL.Var name)
         Core.Free n  ->
           case n of
-            Core.Global s -> pure (EAL.Var (someSymbolVal s))
+            Core.Global s -> pure (EAL.Var (intern s))
+            Core.Local _s -> undefined
+            Core.Quote _s -> undefined
         Core.App a b -> do
           a <- erase b
           b <- erase b
           pure (EAL.App a b)
         Core.Ann _ _ a -> do
           erase a
+        Core.Nat _nat -> undefined
     _               -> undefined
 
 unDeBruijin ∷ (HasState "nextName" Int m,
                 HasState "nameStack" [Int] m)
- ⇒ Int → m SomeSymbol
+ ⇒ Int → m Symbol
 unDeBruijin ind = do
   stack <- get @"nameStack"
-  pure (someSymbolVal $ show $ stack !! ind)
+  pure (intern $ show $ stack !! ind)
 
 newName ∷ (HasState "nextName" Int m,
            HasState "nameStack" [Int] m)
-  ⇒ m SomeSymbol
+  ⇒ m Symbol
 newName = do
   name <- get @"nextName"
   modify @"nextName" (+ 1)
   modify @"nameStack" ((:) name)
-  return (someSymbolVal (show name))
+  return (intern (show name))
 
 data Env = Env {
   typeAssignment :: EAL.TypeAssignment,

--- a/src/Juvix/Core/Erasure.hs
+++ b/src/Juvix/Core/Erasure.hs
@@ -26,6 +26,8 @@ erase term =
     Core.Lam body -> do
       name <- newName
       let ty = EAL.SymT name
+      -- TODO :: replace map here with unordered map
+      -- the remove the Ord deriving from the Symbol type.
       modify @"typeAssignment" (insert name ty)
       body <- erase body
       pure (EAL.Lam name body)

--- a/src/Juvix/EAL/Parser.hs
+++ b/src/Juvix/EAL/Parser.hs
@@ -110,8 +110,8 @@ types = buildExpressionParser optable types'
 types' ∷ Parser PType
 types' = bangs <|> specific
 
-symbol ∷ Stream s m Char ⇒ ParsecT s u m SomeSymbol
-symbol = someSymbolVal <$> identifier
+symbol ∷ Stream s m Char ⇒ ParsecT s u m Symbol
+symbol = intern <$> identifier
 
 lambda ∷ Parser RPTI
 lambda = do

--- a/src/Juvix/EAL/Types.hs
+++ b/src/Juvix/EAL/Types.hs
@@ -7,21 +7,21 @@ import           Juvix.Utility
 
 -- Untyped term.
 data Term
-  = Var SomeSymbol
+  = Var Symbol
   | App Term Term
-  | Lam SomeSymbol Term
+  | Lam Symbol Term
   deriving (Show, Eq)
 
 -- Simple type.
 data Type
-  = SymT SomeSymbol
+  = SymT Symbol
   | ArrT Type Type
   deriving (Show, Eq)
 
 -- Restricted pseudoterm (inner).
 data RPTI
-  = RVar SomeSymbol
-  | RLam SomeSymbol RPTO
+  = RVar Symbol
+  | RLam Symbol RPTO
   | RApp RPTO RPTO
   deriving (Show, Eq)
 
@@ -34,7 +34,7 @@ data RPTO
 type RPT = RPTO
 
 -- Simple type assignment (alias).
-type TypeAssignment = Map.Map SomeSymbol Type
+type TypeAssignment = Map.Map Symbol Type
 
 -- Parameterized restricted pseudoterm (alias).
 type PRPT = RPT
@@ -44,12 +44,12 @@ type Param = Int
 
 -- Parameterized type.
 data PType
-  = PSymT Param SomeSymbol
+  = PSymT Param Symbol
   | PArrT Param PType PType
   deriving (Show, Eq)
 
 -- Parameterized type assignment (alias).
-type ParamTypeAssignment = Map.Map SomeSymbol PType
+type ParamTypeAssignment = Map.Map Symbol PType
 
 -- Linear (in)equality constraint on parameters.
 data Constraint = Constraint {
@@ -73,10 +73,10 @@ data Op
 type Path = [Param]
 
 -- Variable paths.
-type VarPaths = Map SomeSymbol Param
+type VarPaths = Map Symbol Param
 
 -- Occurrence map.
-type OccurrenceMap = Map SomeSymbol Int
+type OccurrenceMap = Map Symbol Int
 
 -- | Bracket Error Types
 data BracketErrors = TooManyOpen
@@ -111,12 +111,12 @@ data Errors = Typ TypeErrors
 -- Environment for errors.
 newtype EnvError a = EnvError (ExceptT TypeErrors (State Info) a)
   deriving (Functor, Applicative, Monad)
-  deriving (HasState "ctxt" (Map SomeSymbol Type)) via
+  deriving (HasState "ctxt" (Map Symbol Type)) via
     Field "ctxt" () (MonadState (ExceptT TypeErrors (State Info)))
   deriving (HasThrow "typ" TypeErrors) via
     MonadError (ExceptT TypeErrors (State Info))
 
-data Info = I {ctxt :: Map SomeSymbol Type} deriving (Show, Generic)
+data Info = I {ctxt :: Map Symbol Type} deriving (Show, Generic)
 
 -- Environment for inference.
 data Env = Env {

--- a/src/Juvix/Encoding/Encoding.hs
+++ b/src/Juvix/Encoding/Encoding.hs
@@ -13,10 +13,10 @@ import           Juvix.Library        hiding (Product, Sum)
 -- | caseGen takes an Case form and generates the proper expanded form
 -- takes a few arguments to determine what to do when there are no arguments to
 -- a case and how to combine the different cases
-caseGen ∷ ( HasState "constructors" (Map SomeSymbol Bound)    m
-          , HasState "adtMap"       (Map SomeSymbol Branches) m
+caseGen ∷ ( HasState "constructors" (Map Symbol Bound)    m
+          , HasState "adtMap"       (Map Symbol Branches) m
           , HasThrow "err"          Errors                    m
-          , HasWriter "missingCases" [SomeSymbol]             m )
+          , HasWriter "missingCases" [Symbol]             m )
         ⇒ Switch
         → (Lambda → Lambda)           -- What to do when there are no arguments?
         → (Lambda → Lambda → Lambda)  -- How does the recursive case work?
@@ -58,11 +58,11 @@ caseGen (Case on cases@(C c _ _ :_)) onNoArg onRec = do
 
 -- Helper for Mendler and Scott encodings --------------------------------------
 
-adtConstructor ∷ ( HasState "adtMap" (Map SomeSymbol [k]) m
+adtConstructor ∷ ( HasState "adtMap" (Map Symbol [k]) m
                  , HasState "constructors" (Map k Bound)  m
                  , HasThrow "err" Errors                  m
                  , Ord k
-                 ) ⇒ k → Lambda → SomeSymbol → m ()
+                 ) ⇒ k → Lambda → Symbol → m ()
 adtConstructor s prod name = do
   modify' @"adtMap" (Map.alter (\case
                                    Nothing → Just [s]
@@ -76,7 +76,7 @@ adtConstructor s prod name = do
 -- generic lambda helpers ------------------------------------------------------
 
 idL ∷ Lambda
-idL = Lambda (someSymbolVal "x") (Value (someSymbolVal "x"))
+idL = Lambda (intern "x") (Value (intern "x"))
 
 app ∷ Lambda → Lambda → Lambda
 app (Lambda s t) replace = rec' t

--- a/src/Juvix/Encoding/Scott.hs
+++ b/src/Juvix/Encoding/Scott.hs
@@ -9,8 +9,8 @@ import           Juvix.Encoding.Types
 import           Juvix.Library           hiding (Product, Sum)
 
 
-adtToScott  ∷ ( HasState "constructors" (Map SomeSymbol Bound)    m
-              , HasState "adtMap"       (Map SomeSymbol Branches) m
+adtToScott  ∷ ( HasState "constructors" (Map Symbol Bound)    m
+              , HasState "adtMap"       (Map Symbol Branches) m
               , HasThrow "err"          Errors                    m )
             ⇒ Name → m ()
 adtToScott (Adt name s) = sumRec s 1 (adtLength s)
@@ -26,18 +26,18 @@ adtToScott (Adt name s) = sumRec s 1 (adtLength s)
 
     sumProd None posAdt lengthAdt = generateLam posAdt lengthAdt identity
     sumProd Term posAdt lengthAdt =
-      Lambda (someSymbolVal "%arg1")
+      Lambda (intern "%arg1")
              (generateLam posAdt
                           lengthAdt
-                          (\b → Application b (Value $ someSymbolVal "%arg1")))
+                          (\b → Application b (Value $ intern "%arg1")))
     sumProd p@(Product _) posAdt lengthAdt = args (lengthProd p)
       where
-        args prodLen = foldr (\spot → Lambda (someSymbolVal $ "%arg" <> show spot))
+        args prodLen = foldr (\spot → Lambda (intern $ "%arg" <> show spot))
                              (encoding prodLen)
                              [1..prodLen]
         encoding prodLen = generateLam posAdt lengthAdt $
           \body →
-            foldl (\acc i → Application acc (Value $ someSymbolVal
+            foldl (\acc i → Application acc (Value $ intern
                                                    $ "%arg" <> show i))
                   body
                   [1..prodLen]
@@ -46,14 +46,14 @@ adtToScott (Adt name s) = sumRec s 1 (adtLength s)
         lengthProd None        = 0 -- I'm skeptical this case ever happens
 
     generateLam posAdt lengthAdt onPosAdt =
-      foldr (\spot → Lambda (someSymbolVal $ "%genArg" <> show spot))
-            (onPosAdt $ Value (someSymbolVal $ "%genArg" <> show posAdt))
+      foldr (\spot → Lambda (intern $ "%genArg" <> show spot))
+            (onPosAdt $ Value (intern $ "%genArg" <> show posAdt))
             [1..lengthAdt]
 
-scottCase ∷ ( HasState "constructors" (Map SomeSymbol Bound)    m
-            , HasState "adtMap"       (Map SomeSymbol Branches) m
+scottCase ∷ ( HasState "constructors" (Map Symbol Bound)    m
+            , HasState "adtMap"       (Map Symbol Branches) m
             , HasThrow "err"          Errors                    m
-            , HasWriter "missingCases" [SomeSymbol]             m )
+            , HasWriter "missingCases" [Symbol]             m )
           ⇒ Switch → m Lambda
 scottCase c = do
   -- expandedCase ends up coming out backwards in terms of application

--- a/src/Juvix/Encoding/Types.hs
+++ b/src/Juvix/Encoding/Types.hs
@@ -9,18 +9,18 @@ data Product = Product Product
              | None
              deriving Show
 
-data Sum = Branch SomeSymbol Product Sum
-         | Single SomeSymbol Product
+data Sum = Branch Symbol Product Sum
+         | Single Symbol Product
          deriving Show
 
-data Name = Adt SomeSymbol Sum
+data Name = Adt Symbol Sum
           deriving Show
 
 -- Object Syntax ---------------------------------------------------------------
 
 -- Replace with bohm later!
-data Lambda = Lambda SomeSymbol Lambda
-            | Value SomeSymbol
+data Lambda = Lambda Symbol Lambda
+            | Value Symbol
             | Application Lambda Lambda
             deriving Show
 
@@ -31,11 +31,11 @@ data Lambda = Lambda SomeSymbol Lambda
 -- /| S n → body
 data Switch = Case Lambda [Case]
 
-type Argument = SomeSymbol
+type Argument = Symbol
 
 type Body = Lambda
 
-data Case = C SomeSymbol [Argument] Body
+data Case = C Symbol [Argument] Body
 
 -- Environment type-------------------------------------------------------------
 -- TODO :: Add smaller environments for testing
@@ -45,38 +45,38 @@ data Case = C SomeSymbol [Argument] Body
 -- One function does not require constructor, the other does not have
 -- the missingCase writer
 
-type Branches = [SomeSymbol]
+type Branches = [Symbol]
 
 data Bound = Bound { lam     :: Lambda
                    -- This is to remember what ADΤ we belong to
-                   , adtName :: SomeSymbol
+                   , adtName :: Symbol
                    } deriving (Show, Generic)
 
-data Env = Env { constructors :: Map SomeSymbol Bound
+data Env = Env { constructors :: Map Symbol Bound
                -- | adtMap is a mapping between the adt name and the ordered cases thereof
-               , adtMap       :: Map SomeSymbol Branches
+               , adtMap       :: Map Symbol Branches
                -- | missingCases represent the missing cases of a match
-               , missingCases :: [SomeSymbol]
+               , missingCases :: [Symbol]
                } deriving (Show, Generic)
 
 data Errors = AlreadyDefined
-            | NotInAdt   SomeSymbol
-            | NotInMatch SomeSymbol SomeSymbol
-            | AdtNotDefined SomeSymbol
+            | NotInAdt   Symbol
+            | NotInMatch Symbol Symbol
+            | AdtNotDefined Symbol
             | MatchWithoutCases
             | InvalidAdt
             deriving Show
 
 newtype EnvS a = EnvS (StateT Env (Except Errors) a)
   deriving (Functor, Applicative, Monad)
-  deriving (HasState "constructors" (Map SomeSymbol Bound)) via
+  deriving (HasState "constructors" (Map Symbol Bound)) via
     Field "constructors" () (MonadState (StateT Env (Except Errors)))
-  deriving (HasState "adtMap" (Map SomeSymbol Branches)) via
+  deriving (HasState "adtMap" (Map Symbol Branches)) via
     Field "adtMap" () (MonadState (StateT Env (Except Errors)))
   deriving (HasThrow "err" Errors) via
     MonadError (StateT Env (Except Errors))
-  deriving ( HasStream "missingCases" [SomeSymbol]
-           , HasWriter "missingCases" [SomeSymbol] ) via
+  deriving ( HasStream "missingCases" [Symbol]
+           , HasWriter "missingCases" [Symbol] ) via
     WriterLog (Field "missingCases" () (MonadState (StateT Env (Except Errors))))
 
 runEnvsS ∷ EnvS a → Either Errors (a, Env)

--- a/src/Juvix/Library.hs
+++ b/src/Juvix/Library.hs
@@ -5,7 +5,7 @@ module Juvix.Library ( module Protolude
                      , module Capability.Writer
                      , module Capability.Stream
                      , (∨), (∧), (|<<), (>>|), (|>)
-                     , traverseM
+                     , traverseM, Symbol, intern
                      ) where
 
 import           Capability.Error
@@ -13,12 +13,13 @@ import           Capability.Reader
 import           Capability.State
 import           Capability.Stream
 import           Capability.Writer
-import           Prelude           (Show (..))
+import qualified Data.Text         as T
+import           Prelude           (Show (..), String)
 import           Protolude         hiding ((:.:), Constraint, Fixity (..),
                                     MonadError (..), MonadReader (..),
                                     MonadState (..), ask, asks, catch,
                                     catchJust, get, gets, local, modify, pass,
-                                    put, reader, state)
+                                    put, reader, state, SomeSymbol, Symbol)
 
 (∨) ∷ Bool → Bool → Bool
 (∨) = (||)
@@ -48,3 +49,12 @@ traverseM f = fmap join . traverse f
 
 instance Show ((->) a b) where
   show _ = "fun"
+
+
+newtype Symbol = Sym Text deriving (Eq, Ord)
+
+instance Show Symbol where
+  show (Sym t) = T.unpack t
+
+intern :: String → Symbol
+intern = Sym . T.pack

--- a/src/Juvix/Library.hs
+++ b/src/Juvix/Library.hs
@@ -5,7 +5,7 @@ module Juvix.Library ( module Protolude
                      , module Capability.Writer
                      , module Capability.Stream
                      , (∨), (∧), (|<<), (>>|), (|>)
-                     , traverseM, Symbol, intern
+                     , traverseM, Symbol, intern, unintern
                      ) where
 
 import           Capability.Error
@@ -56,5 +56,8 @@ newtype Symbol = Sym Text deriving (Eq, Ord)
 instance Show Symbol where
   show (Sym t) = T.unpack t
 
-intern :: String → Symbol
+intern ∷ String → Symbol
 intern = Sym . T.pack
+
+unintern ∷ Symbol → String
+unintern (Sym s) = T.unpack s

--- a/src/Juvix/Nets/Bohm.hs
+++ b/src/Juvix/Nets/Bohm.hs
@@ -48,7 +48,7 @@ data Primar = Erase
             | Tru
             | Fals
             | IntLit Int
-            | Symbol SomeSymbol
+            | Symbol Symbol
             deriving Show
 
 

--- a/test/Eal.hs
+++ b/test/Eal.hs
@@ -16,11 +16,11 @@ parseTest3 = parseEal "!!(λ x : Forall. !-!-x λx : a -o b -o c. !-!-(x y))"
 
 exampleBracket ∷ RPTO
 exampleBracket =
-  RBang 0 (RLam (someSymbolVal "y")
-    (RBang 0 (RLam (someSymbolVal "z")
-               (RBang 1 (RApp (RBang 0 (RApp (RBang (-1) (RVar (someSymbolVal "y")))
-                                         (RBang (-1) (RVar (someSymbolVal "y")))))
-                            (RBang (-1) (RVar (someSymbolVal "z"))))))))
+  RBang 0 (RLam (intern "y")
+    (RBang 0 (RLam (intern "z")
+               (RBang 1 (RApp (RBang 0 (RApp (RBang (-1) (RVar (intern "y")))
+                                         (RBang (-1) (RVar (intern "y")))))
+                            (RBang (-1) (RVar (intern "z"))))))))
 
 exampleBracketRun ∷ Either BracketErrors ()
 exampleBracketRun = bracketChecker exampleBracket

--- a/test/Eal2.hs
+++ b/test/Eal2.hs
@@ -40,81 +40,81 @@ shouldNotBeTypeable term assignment =
       Left _  -> pure ()
 
 idTerm ∷ Term
-idTerm = Lam (someSymbolVal "x") (Var (someSymbolVal "x"))
+idTerm = Lam (intern "x") (Var (intern "x"))
 
 idAssignment ∷ TypeAssignment
-idAssignment = Map.fromList [ (someSymbolVal "x", SymT (someSymbolVal "a")) ]
+idAssignment = Map.fromList [ (intern "x", SymT (intern "a")) ]
 
 churchTwo ∷ Term
-churchTwo = Lam (someSymbolVal "s")
-             (Lam (someSymbolVal "z")
-               (App (Var (someSymbolVal "s"))
-                    (App (Var (someSymbolVal "s"))
-                         (Var (someSymbolVal "z")))))
+churchTwo = Lam (intern "s")
+             (Lam (intern "z")
+               (App (Var (intern "s"))
+                    (App (Var (intern "s"))
+                         (Var (intern "z")))))
 
 churchThree ∷ Term
-churchThree = Lam (someSymbolVal "s")
-             (Lam (someSymbolVal "z")
-               (App (Var (someSymbolVal "s"))
-                    (App (Var (someSymbolVal "s"))
-                         (App (Var (someSymbolVal "s"))
-                              (Var (someSymbolVal "z"))))))
+churchThree = Lam (intern "s")
+             (Lam (intern "z")
+               (App (Var (intern "s"))
+                    (App (Var (intern "s"))
+                         (App (Var (intern "s"))
+                              (Var (intern "z"))))))
 
 churchAssignment ∷ TypeAssignment
 churchAssignment = Map.fromList [
-  (someSymbolVal "s", ArrT (SymT (someSymbolVal "a")) (SymT (someSymbolVal "a"))),
-  (someSymbolVal "z", SymT (someSymbolVal "a"))
+  (intern "s", ArrT (SymT (intern "a")) (SymT (intern "a"))),
+  (intern "z", SymT (intern "a"))
   ]
 
 -- \y -> ( (\n -> n (\y -> n (\_ -> y))) (\x -> (x (x y))) ) :: a -> a
 counterexample ∷ Term
 counterexample =
   App
-    (Lam (someSymbolVal "n")
-      (App (Var (someSymbolVal "n"))
-           (Lam (someSymbolVal "y")
-              (App (Var (someSymbolVal "n"))
-                        (Lam (someSymbolVal "z")
-                        (Var (someSymbolVal "y")))
+    (Lam (intern "n")
+      (App (Var (intern "n"))
+           (Lam (intern "y")
+              (App (Var (intern "n"))
+                        (Lam (intern "z")
+                        (Var (intern "y")))
             )
       )
     ))
-    (Lam (someSymbolVal "x")
-      (App (Var (someSymbolVal "x"))
-           (App (Var (someSymbolVal "x"))
-                (Var (someSymbolVal "y")))))
+    (Lam (intern "x")
+      (App (Var (intern "x"))
+           (App (Var (intern "x"))
+                (Var (intern "y")))))
 
 arg0 ∷ Type
-arg0 = SymT (someSymbolVal "a")
+arg0 = SymT (intern "a")
 
 arg1 ∷ Type
-arg1 = ArrT (SymT (someSymbolVal "a"))
-            (SymT (someSymbolVal "a"))
+arg1 = ArrT (SymT (intern "a"))
+            (SymT (intern "a"))
 
-counterexampleAssignment ∷ Map SomeSymbol Type
+counterexampleAssignment ∷ Map Symbol Type
 counterexampleAssignment = Map.fromList
-  [ (someSymbolVal "n", ArrT arg1 arg0)
-  , (someSymbolVal "y", arg0)
-  , (someSymbolVal "z", arg0)
-  , (someSymbolVal "x", arg1)
+  [ (intern "n", ArrT arg1 arg0)
+  , (intern "y", arg0)
+  , (intern "z", arg0)
+  , (intern "x", arg1)
   ]
 
 exp ∷ Term
 exp =
-  (Lam (someSymbolVal "m")
-   (Lam (someSymbolVal "n")
-    (Lam (someSymbolVal "s")
-     (Lam (someSymbolVal "z")
-       (App (App (App (Var (someSymbolVal "m"))
-                 (Var (someSymbolVal "n")))
-            (Var (someSymbolVal "s")))
-            (Var (someSymbolVal "z")))))))
+  (Lam (intern "m")
+   (Lam (intern "n")
+    (Lam (intern "s")
+     (Lam (intern "z")
+       (App (App (App (Var (intern "m"))
+                 (Var (intern "n")))
+            (Var (intern "s")))
+            (Var (intern "z")))))))
 
 threeLam ∷ Term
-threeLam = Lam (someSymbolVal "f") (Lam (someSymbolVal "x") (nTimesApp 10 (Var (someSymbolVal "f")) (Var (someSymbolVal "x"))))
+threeLam = Lam (intern "f") (Lam (intern "x") (nTimesApp 10 (Var (intern "f")) (Var (intern "x"))))
 
 threeLam2 ∷ Term
-threeLam2 = Lam (someSymbolVal "f'") (Lam (someSymbolVal "x'") (nTimesApp 20 (Var (someSymbolVal "f'")) (Var (someSymbolVal "x'"))))
+threeLam2 = Lam (intern "f'") (Lam (intern "x'") (nTimesApp 20 (Var (intern "f'")) (Var (intern "x'"))))
 
 nTimesApp ∷ Int → Term → Term → Term
 nTimesApp 0 _ b = b
@@ -125,16 +125,16 @@ churchExp2 = exp
 
 churchExp ∷ Term
 churchExp =
-    (Lam (someSymbolVal "s'")
-      (Lam (someSymbolVal "z'")
+    (Lam (intern "s'")
+      (Lam (intern "z'")
         (App (App (App (App exp
                             threeLam)
                        threeLam2)
-                  (Var (someSymbolVal "s'")))
-             (Var (someSymbolVal "z'")))))
+                  (Var (intern "s'")))
+             (Var (intern "z'")))))
 
 zTy ∷ Type
-zTy = SymT (someSymbolVal "a")
+zTy = SymT (intern "a")
 
 sTy ∷ Type
 sTy = ArrT zTy zTy
@@ -144,16 +144,16 @@ nat = ArrT sTy sTy
 
 churchExpAssignment ∷ TypeAssignment
 churchExpAssignment = Map.fromList
-  [ (someSymbolVal "n", nat)
-  , (someSymbolVal "m", ArrT nat nat)
-  , (someSymbolVal "s", sTy)
-  , (someSymbolVal "s'", sTy)
-  , (someSymbolVal "z", zTy)
-  , (someSymbolVal "z'", zTy)
-  , (someSymbolVal "x'", zTy)
-  , (someSymbolVal "x", sTy)
-  , (someSymbolVal "f'", sTy)
-  , (someSymbolVal "f", nat)
+  [ (intern "n", nat)
+  , (intern "m", ArrT nat nat)
+  , (intern "s", sTy)
+  , (intern "s'", sTy)
+  , (intern "z", zTy)
+  , (intern "z'", zTy)
+  , (intern "x'", zTy)
+  , (intern "x", sTy)
+  , (intern "f'", sTy)
+  , (intern "f", nat)
   ]
 
 {- Examples from 3.0.1 of Asperti's book; they don't seem to typecheck though. -}

--- a/test/Encoding.hs
+++ b/test/Encoding.hs
@@ -7,51 +7,51 @@ import           Juvix.Encoding.Types
 import           Juvix.Library           hiding (Product, Sum)
 
 userNat ∷ Name
-userNat = Adt (someSymbolVal "Nat")
-              (Branch (someSymbolVal "Z") None
-                      (Single (someSymbolVal "S") Term))
+userNat = Adt (intern "Nat")
+              (Branch (intern "Z") None
+                      (Single (intern "S") Term))
 
 dUserNat ∷ Name
-dUserNat = Adt (someSymbolVal "Nat")
-               (Branch (someSymbolVal "Z") None
-                       (Branch (someSymbolVal "S") Term
-                               (Single (someSymbolVal "D") (Product Term))))
+dUserNat = Adt (intern "Nat")
+               (Branch (intern "Z") None
+                       (Branch (intern "S") Term
+                               (Single (intern "D") (Product Term))))
 
 
 -- Test cases for Nat ----------------------------------------------------------
 zero' ∷ Lambda
-zero' = app in' (app inl (Lambda (someSymbolVal "x")
-                           (Value (someSymbolVal "x"))))
+zero' = app in' (app inl (Lambda (intern "x")
+                           (Value (intern "x"))))
 
 succ' ∷ Lambda
-succ' = Lambda (someSymbolVal "c%gen1")
-               (app in' (app inr (app inl (Value (someSymbolVal "c%gen1")))))
+succ' = Lambda (intern "c%gen1")
+               (app in' (app inr (app inl (Value (intern "c%gen1")))))
 
 dup' ∷ Lambda
-dup' = Lambda (someSymbolVal "c%gen1")
-       (Lambda (someSymbolVal "c%gen2")
+dup' = Lambda (intern "c%gen1")
+       (Lambda (intern "c%gen2")
          (app in' (app inr
-                    (app inrOp (Lambda (someSymbolVal "%fun")
+                    (app inrOp (Lambda (intern "%fun")
                                  (Application
-                                   (Application (Value $ someSymbolVal "%fun")
-                                                (Value $ someSymbolVal "c%gen1"))
-                                   (Value $ someSymbolVal "c%gen2")))))))
+                                   (Application (Value $ intern "%fun")
+                                                (Value $ intern "c%gen1"))
+                                   (Value $ intern "c%gen2")))))))
 
 test2D ∷ Either Errors (Lambda, Env)
 test2D = runEnvsS $ do
   adtToMendler dUserNat
-  mendlerCase (Case (Value $ someSymbolVal "val")
-                  [ C (someSymbolVal "Z") []
-                      (Value $ someSymbolVal "True")
-                  , C (someSymbolVal "S") [someSymbolVal "n"]
-                      (Application (Value $ someSymbolVal "not")
-                                   (Application (Value $ someSymbolVal "rec")
-                                                (Value $ someSymbolVal "n")))
-                  , C (someSymbolVal "D") [someSymbolVal "n1"
-                                          , someSymbolVal "n2"]
-                      (Application (Value $ someSymbolVal "not")
-                                   (Application (Value $ someSymbolVal "rec")
-                                                (Value $ someSymbolVal "n1")))
+  mendlerCase (Case (Value $ intern "val")
+                  [ C (intern "Z") []
+                      (Value $ intern "True")
+                  , C (intern "S") [intern "n"]
+                      (Application (Value $ intern "not")
+                                   (Application (Value $ intern "rec")
+                                                (Value $ intern "n")))
+                  , C (intern "D") [intern "n1"
+                                          , intern "n2"]
+                      (Application (Value $ intern "not")
+                                   (Application (Value $ intern "rec")
+                                                (Value $ intern "n1")))
                   ])
 
 -- let rec f x i =
@@ -63,69 +63,69 @@ test2D = runEnvsS $ do
 test3D ∷ Either Errors (Lambda, Env)
 test3D = runEnvsS $ do
   adtToMendler dUserNat
-  mendlerCase (Case (Value $ someSymbolVal "val")
-                  [ C (someSymbolVal "Z") []
-                      (Value $ someSymbolVal "i")
-                  , C (someSymbolVal "S") [someSymbolVal "n"]
-                      (Application (Application (Value $ someSymbolVal "+")
-                                                (Value $ someSymbolVal "1"))
-                                   (Application (Application (Value $ someSymbolVal "rec")
-                                                             (Value $ someSymbolVal "n"))
-                                                (Value $ someSymbolVal "i")))
-                  , C (someSymbolVal "D") [someSymbolVal "n1"
-                                          , someSymbolVal "n2"]
-                      (Application (Application (Value $ someSymbolVal "+")
-                                                (Application (Application (Value $ someSymbolVal "rec")
-                                                                          (Value $ someSymbolVal "n2"))
-                                                             (Value $ someSymbolVal "0")))
-                                   (Application (Application (Value $ someSymbolVal "rec")
-                                                             (Value $ someSymbolVal "n1"))
-                                                (Value $ someSymbolVal "i")))
+  mendlerCase (Case (Value $ intern "val")
+                  [ C (intern "Z") []
+                      (Value $ intern "i")
+                  , C (intern "S") [intern "n"]
+                      (Application (Application (Value $ intern "+")
+                                                (Value $ intern "1"))
+                                   (Application (Application (Value $ intern "rec")
+                                                             (Value $ intern "n"))
+                                                (Value $ intern "i")))
+                  , C (intern "D") [intern "n1"
+                                          , intern "n2"]
+                      (Application (Application (Value $ intern "+")
+                                                (Application (Application (Value $ intern "rec")
+                                                                          (Value $ intern "n2"))
+                                                             (Value $ intern "0")))
+                                   (Application (Application (Value $ intern "rec")
+                                                             (Value $ intern "n1"))
+                                                (Value $ intern "i")))
                   ])
 
 test3D' ∷ Either Errors (Lambda, Env)
 test3D' = runEnvsS $ do
   adtToScott dUserNat
-  scottCase (Case (Value $ someSymbolVal "val")
-                  [ C (someSymbolVal "Z") []
-                      (Value $ someSymbolVal "i")
-                  , C (someSymbolVal "S") [someSymbolVal "n"]
-                      (Application (Application (Value $ someSymbolVal "+")
-                                                (Value $ someSymbolVal "1"))
-                                   (Application (Application (Value $ someSymbolVal "rec")
-                                                             (Value $ someSymbolVal "n"))
-                                                (Value $ someSymbolVal "i")))
-                  , C (someSymbolVal "D") [someSymbolVal "n1"
-                                          , someSymbolVal "n2"]
-                      (Application (Application (Value $ someSymbolVal "+")
-                                                (Application (Application (Value $ someSymbolVal "rec")
-                                                                          (Value $ someSymbolVal "n2"))
-                                                             (Value $ someSymbolVal "0")))
-                                   (Application (Application (Value $ someSymbolVal "rec")
-                                                             (Value $ someSymbolVal "n1"))
-                                                (Value $ someSymbolVal "i")))
+  scottCase (Case (Value $ intern "val")
+                  [ C (intern "Z") []
+                      (Value $ intern "i")
+                  , C (intern "S") [intern "n"]
+                      (Application (Application (Value $ intern "+")
+                                                (Value $ intern "1"))
+                                   (Application (Application (Value $ intern "rec")
+                                                             (Value $ intern "n"))
+                                                (Value $ intern "i")))
+                  , C (intern "D") [intern "n1"
+                                          , intern "n2"]
+                      (Application (Application (Value $ intern "+")
+                                                (Application (Application (Value $ intern "rec")
+                                                                          (Value $ intern "n2"))
+                                                             (Value $ intern "0")))
+                                   (Application (Application (Value $ intern "rec")
+                                                             (Value $ intern "n1"))
+                                                (Value $ intern "i")))
                   ])
 
 test1 ∷ Either Errors (Lambda, Env)
 test1 = runEnvsS $ do
   adtToMendler userNat
-  mendlerCase (Case (Value $ someSymbolVal "val")
-                  [ C (someSymbolVal "Z") []
-                      (Value $ someSymbolVal "True")
-                  , C (someSymbolVal "S") [someSymbolVal "n"]
-                      (Application (Value $ someSymbolVal "not")
-                                   (Application (Value $ someSymbolVal "rec")
-                                                (Value $ someSymbolVal "n")))])
+  mendlerCase (Case (Value $ intern "val")
+                  [ C (intern "Z") []
+                      (Value $ intern "True")
+                  , C (intern "S") [intern "n"]
+                      (Application (Value $ intern "not")
+                                   (Application (Value $ intern "rec")
+                                                (Value $ intern "n")))])
 
 
 test1' ∷ Either Errors (Lambda, Env)
 test1' = runEnvsS $ do
   adtToScott userNat
-  scottCase (Case (Value $ someSymbolVal "val")
-                  [ C (someSymbolVal "Z") []
-                      (Value $ someSymbolVal "True")
-                  , C (someSymbolVal "S") [someSymbolVal "n"]
-                      (Application (Value $ someSymbolVal "not")
-                                   (Application (Value $ someSymbolVal "rec")
-                                                (Value $ someSymbolVal "n")))])
+  scottCase (Case (Value $ intern "val")
+                  [ C (intern "Z") []
+                      (Value $ intern "True")
+                  , C (intern "S") [intern "n"]
+                      (Application (Value $ intern "not")
+                                   (Application (Value $ intern "rec")
+                                                (Value $ intern "n")))])
 


### PR DESCRIPTION
refactors the codebase to use text instead of SomeSymbol

1. this makes a new type Symbol, which is distinct from symbol
  - the interface should just be Eq, however there is one instance of ordering on Symbol,
  - This is left as a todo comment, just need to bring in unordered collections to fix at a later point.