### PR TITLE
Thealmarty/add operations to nats

### DIFF
--- a/app/Interactive.hs
+++ b/app/Interactive.hs
@@ -20,52 +20,51 @@ import qualified Juvix.Nets.Bohm              as Bohm
 
 interactive ∷ Context → Config → IO ()
 interactive ctx _ = do
-  func ← return $ \str -> do
-    return str
+  func <- return $ \str -> do return str
   H.runInputT (settings ctx) (mainLoop func)
 
 settings ∷ Context → H.Settings IO
-settings ctx = H.Settings {
-  H.complete        = H.completeFilename,
-  H.historyFile     = Just (contextHomeDirectory ctx <> "/.jvxi_history"),
-  H.autoAddHistory  = True
-  }
+settings ctx =
+  H.Settings
+    { H.complete = H.completeFilename
+    , H.historyFile = Just (contextHomeDirectory ctx <> "/.jvxi_history")
+    , H.autoAddHistory = True
+    }
 
 mainLoop ∷ (String → IO String) → H.InputT IO ()
 mainLoop func = do
-  input ← H.getInputLine "jvxi >> "
+  input <- H.getInputLine "jvxi >> "
   case input of
-    Nothing → return ()
-    Just i  → do
+    Nothing -> return ()
+    Just i -> do
       case i of
-        (':' : special) →
-          handleSpecial special (mainLoop func)
-        inp → do
+        (':':special) -> handleSpecial special (mainLoop func)
+        inp -> do
           H.outputStrLn =<< liftIO (func inp)
           mainLoop func
 
 handleSpecial ∷ String → H.InputT IO () → H.InputT IO ()
 handleSpecial str cont = do
   case str of
-    "?"    → liftIO (putDoc specialsDoc) >> cont
-    "exit" → return ()
-    "tutorial" → do
+    "?" -> liftIO (putDoc specialsDoc) >> cont
+    "exit" -> return ()
+    "tutorial" -> do
       H.outputStrLn "Interactive tutorial coming soon!"
       cont
-    'c' : 'p' : ' ' : rest -> do
+    'c':'p':' ':rest -> do
       let parsed = Core.parseString Core.cterm rest
       H.outputStrLn $ show parsed
       cont
-    'c' : 't' : ' ' : rest -> do
+    'c':'t':' ':rest -> do
       let parsed = Core.parseString Core.cterm rest
       H.outputStrLn $ show parsed
       case parsed of
         Just cterm -> do
           let eval = Core.cEval cterm []
-          H.outputStrLn $ Core.showVal eval
+          H.outputStrLn $ show eval
         Nothing -> return ()
       cont
-    'c' : 'e' : ' ' : rest -> do
+    'c':'e':' ':rest -> do
       let parsed = Core.parseString Core.cterm rest
       H.outputStrLn $ show parsed
       case parsed of
@@ -77,28 +76,30 @@ handleSpecial str cont = do
             _ -> return ()
         Nothing -> return ()
       cont
-    'e' : 'p' : ' ' : rest -> do
+    'e':'p':' ':rest -> do
       let parsed = EAL.parseEal rest
       case parsed of
         Right r -> transformAndEvaluateEal True r
         _       -> return ()
       cont
-    'e' : 'q' : ' ' : rest -> do
+    'e':'q':' ':rest -> do
       let parsed = EAL.parseEal rest
       case parsed of
         Right r -> transformAndEvaluateEal False r
         _       -> return ()
       cont
-    'e' : 'e' : ' ' : rest -> do
+    'e':'e':' ':rest -> do
       let parsed = EAL.parseEal rest
       H.outputStrLn $ show parsed
       case parsed of
         Right r -> transformAndEvaluateEal True r
         _       -> return ()
       cont
-    _      → H.outputStrLn "Unknown special command" >> cont
+    _ -> H.outputStrLn "Unknown special command" >> cont
 
-eraseAndSolveCore ∷ Core.CTerm → H.InputT IO (Either EAL.Errors (EAL.RPT, EAL.ParamTypeAssignment))
+eraseAndSolveCore ∷
+     Core.CTerm
+  → H.InputT IO (Either EAL.Errors (EAL.RPT, EAL.ParamTypeAssignment))
 eraseAndSolveCore cterm = do
   let (term, typeAssignment) = Core.erase' cterm
   res <- liftIO (EAL.validEal term typeAssignment)
@@ -120,29 +121,30 @@ transformAndEvaluateEal debug term = do
   H.outputStrLn ("Read-back term: " <> show readback)
 
 specialsDoc ∷ Doc
-specialsDoc = mconcat [
-  line,
-  mconcat (fmap (flip (<>) line . specialDoc) specials),
-  line
-  ]
+specialsDoc =
+  mconcat [line, mconcat (fmap (flip (<>) line . specialDoc) specials), line]
 
 specialDoc ∷ Special → Doc
-specialDoc (Special command helpDesc) = text $ T.unpack $ mconcat [":", command, " - ", helpDesc]
+specialDoc (Special command helpDesc) =
+  text $ T.unpack $ mconcat [":", command, " - ", helpDesc]
 
 specials ∷ [Special]
-specials = [
-  Special "cp [term]"   "Parse a Juvix Core term",
-  Special "ct [term}"   "Parse, typecheck, & evaluate a Juvix Core term",
-  Special "ce [term"    "Parse a Juvix Core term, translate to EAL, solve constraints, evaluate & read-back",
-  Special "ep [term]"   "Parse an EAL term",
-  Special "ee [term]"   "Parse an EAL term, evaluate & read-back",
-  Special "eq [term]"   "Parse an EAL term, evaluate & read-back quietly",
-  Special "tutorial"    "Embark upon an interactive tutorial",
-  Special "?"           "Show this help message",
-  Special "exit"        "Quit interactive mode"
+specials =
+  [ Special "cp [term]" "Parse a Juvix Core term"
+  , Special "ct [term}" "Parse, typecheck, & evaluate a Juvix Core term"
+  , Special
+      "ce [term"
+      "Parse a Juvix Core term, translate to EAL, solve constraints, evaluate & read-back"
+  , Special "ep [term]" "Parse an EAL term"
+  , Special "ee [term]" "Parse an EAL term, evaluate & read-back"
+  , Special "eq [term]" "Parse an EAL term, evaluate & read-back quietly"
+  , Special "tutorial" "Embark upon an interactive tutorial"
+  , Special "?" "Show this help message"
+  , Special "exit" "Quit interactive mode"
   ]
 
-data Special = Special {
-  specialCommand  ∷ Text,
-  specialHelpDesc ∷ Text
-}
+data Special =
+  Special
+    { specialCommand  :: Text
+    , specialHelpDesc :: Text
+    }

--- a/package.yaml
+++ b/package.yaml
@@ -68,6 +68,7 @@ library:
   exposed-modules:
     - Juvix
     - Juvix.Core
+    - Juvix.Core.MainLang
     - Juvix.EAL
     - Juvix.EAL.Check
     - Juvix.EAL.EAL

--- a/package.yaml
+++ b/package.yaml
@@ -127,6 +127,7 @@ tests:
       - tasty
       - tasty-hunit
       - tasty-quickcheck
+      - QuickCheck
       - tasty-discover
       - temporary
       - raw-strings-qq

--- a/package.yaml
+++ b/package.yaml
@@ -126,6 +126,7 @@ tests:
       - juvix
       - tasty
       - tasty-hunit
+      - tasty-quickcheck
       - tasty-discover
       - temporary
       - raw-strings-qq

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -87,10 +87,15 @@ data Value
   | VNeutral Neutral
   | VNat Natural
 
+--TODO, eq instance for value -> value
 instance Eq Value where
   VStar x == VStar y = x == y
+  VNats == VNats = True
+  --VPi pi1 x1 y1 == VPi pi2 x2 y2 = pi1 == pi2 && x1 == x2 && y1 == y2
+  VNPm x1 y1 == VNPm x2 y2 = x1 == x2 && y1 == y2
   VNeutral x == VNeutral y = x == y
   VNat x == VNat y = x == y
+  _ == _ = False
 
 instance Show Value where
   show (VLam f) = showFun f

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -87,12 +87,22 @@ data Value
   | VNeutral Neutral
   | VNat Natural
 
---TODO, eq instance for value -> value
+--(Value -> Value) are equal when given an arbitrary value they return the same value.
+valueToValueEq ∷ (Value → Value) → (Value → Value) → Bool
+valueToValueEq y1 y2 =
+  y1 (VNeutral (NFree (Global "x"))) == y2 (VNeutral (NFree (Global "x")))
+
 instance Eq Value where
   VStar x == VStar y = x == y
   VNats == VNats = True
-  --VPi pi1 x1 y1 == VPi pi2 x2 y2 = pi1 == pi2 && x1 == x2 && y1 == y2
+  VPi pi1 x1 y1 == VPi pi2 x2 y2 =
+    pi1 == pi2 && x1 == x2 && valueToValueEq y1 y2
+  VPm pi1 x1 y1 == VPm pi2 x2 y2 =
+    pi1 == pi2 && x1 == x2 && valueToValueEq y1 y2
+  VPa pi1 x1 y1 == VPa pi2 x2 y2 =
+    pi1 == pi2 && x1 == x2 && valueToValueEq y1 y2
   VNPm x1 y1 == VNPm x2 y2 = x1 == x2 && y1 == y2
+  VLam x == VLam y = valueToValueEq x y
   VNeutral x == VNeutral y = x == y
   VNat x == VNat y = x == y
   _ == _ = False

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -87,10 +87,12 @@ data Value
   | VNeutral Neutral
   | VNat Natural
 
+varX ∷ Value
+varX = (VNeutral (NFree (Global "x")))
+
 --(Value -> Value) are equal when given an arbitrary value they return the same value.
 valueToValueEq ∷ (Value → Value) → (Value → Value) → Bool
-valueToValueEq y1 y2 =
-  y1 (VNeutral (NFree (Global "x"))) == y2 (VNeutral (NFree (Global "x")))
+valueToValueEq y1 y2 = y1 varX == y2 varX
 
 instance Eq Value where
   VStar x == VStar y = x == y
@@ -108,19 +110,16 @@ instance Eq Value where
   _ == _ = False
 
 instance Show Value where
-  show (VLam f) = showFun f
+  show (VLam f) = show (f varX)
   show (VStar i) = "* " ++ show i
   show VNats = "Nats "
-  show (VPi n v f) = "[" ++ show n ++ "] " ++ show v ++ " -> " ++ showFun f
+  show (VPi n v f) = "[" ++ show n ++ "] " ++ show v ++ " -> " ++ show (f varX)
   show (VPm n v f) =
-    "([" ++ show n ++ "] " ++ show v ++ ", " ++ showFun f ++ ") "
+    "([" ++ show n ++ "] " ++ show v ++ ", " ++ show (f varX) ++ ") "
   show (VPa _ _ _) = "/\\ "
   show (VNPm _ _) = "\\/ "
   show (VNeutral _n) = "neutral "
   show (VNat i) = show i
-
-showFun ∷ (Value → Value) → String
-showFun _f = "\\x.t "
 
 --A neutral term is either a variable or an application of a neutral term to a value
 data Neutral

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -69,6 +69,27 @@ data ITerm
   | Ann Usage CTerm CTerm --Annotation with usage.
   deriving (Show, Eq)
 
+-- addition of nats
+natAdd ∷ ITerm → ITerm → ITerm
+natAdd (Nat x) (Nat y) = Nat (x + y)
+natAdd (Nat _x) y = error (show y ++ " is not a Nat.")
+natAdd x (Nat _y) = error (show x ++ " is not a Nat.")
+natAdd x y = error ("Neither " ++ show x ++ " nor " ++ show y ++ " is a Nat.")
+
+-- substraction of nats
+natSub ∷ ITerm → ITerm → ITerm
+natSub (Nat x) (Nat y) = Nat (x - y)
+natSub (Nat _x) y = error (show y ++ " is not a Nat.")
+natSub x (Nat _y) = error (show x ++ " is not a Nat.")
+natSub x y = error ("Neither " ++ show x ++ " nor " ++ show y ++ " is a Nat.")
+
+-- multiplication of nats
+natMult ∷ ITerm → ITerm → ITerm
+natMult (Nat x) (Nat y) = Nat (x * y)
+natMult (Nat _x) y = error (show y ++ " is not a Nat.")
+natMult x (Nat _y) = error (show x ++ " is not a Nat.")
+natMult x y = error ("Neither " ++ show x ++ " nor " ++ show y ++ " is a Nat.")
+
 data Name
   = Global String -- Global variables are represented by name thus type string
   | Local Natural -- to convert a bound variable into a free one
@@ -88,7 +109,7 @@ data Value
   | VNat Natural
 
 varX ∷ Value
-varX = (VNeutral (NFree (Global "x")))
+varX = VNeutral (NFree (Global "x"))
 
 --(Value -> Value) are equal when given an arbitrary value they return the same value.
 valueToValueEq ∷ (Value → Value) → (Value → Value) → Bool
@@ -125,7 +146,7 @@ instance Show Value where
 data Neutral
   = NFree Name
   | NApp Neutral Value
-  deriving (Eq)
+  deriving (Show, Eq)
 
 --vfree creates the value corresponding to a free variable
 vfree ∷ Name → Value

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -55,7 +55,7 @@ instance Show CTerm where
     "([π] " ++ show first ++ ", " ++ show second ++ ") "
   show (Pa _usage first second) = "/\\ " ++ show first ++ show second
   show (NPm first second) = "\\/ " ++ show first ++ show second
-  show (Lam var) = "\\ " ++ show var
+  show (Lam var) = "\\x. " ++ show var
   show (Conv term) --Conv should be invisible to users.
    = show term
 

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -69,8 +69,8 @@ data ITerm
   deriving (Eq)
 
 instance Show ITerm where
-  show (Bound i) = "Bound " ++ show i
-  show (Free name) = show name
+  show (Bound i) = "Bound " ++ show i --to be improved
+  show (Free name) = show name --using derived show Name instance, to be improved
   show (Nat i) = show i
   show (App f x) = show f ++ show x
   show (Ann pi theTerm theType) =

--- a/test/MainLangTests.hs
+++ b/test/MainLangTests.hs
@@ -45,8 +45,7 @@ test_core =
         [ testCase "Nats is of type * 0" natsTypeStar0
         , testCase "Inferred type of Nat 1 is (w, VNats)" nat1Inferred
         ]
-    , testGroup
-        "Evaluator Properties"
-        [testProperty "Constant terms should evaluate to themselves" constProp]
+    --, testGroup "Evaluator Properties"
+    --   [testProperty "Constant terms should evaluate to themselves" constProp]
     --, testGroup "Type-checker Properties" [testProperty "Quickcheck test" arith]
     ]

--- a/test/MainLangTests.hs
+++ b/test/MainLangTests.hs
@@ -6,11 +6,8 @@ import           Juvix.Core.MainLang
 import           Prelude
 import           Test.Tasty
 import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
 
---import           Test.Tasty.QuickCheck
---import qualified Test.Tasty.SmallCheck as SC
---import           Test.HUnit          (Assertion, (@?=))
---import qualified Test.QuickCheck     as QC
 --property tests of type checker:
 --the term's inferred type equals to the input type
 --property test of evaluator:
@@ -26,8 +23,9 @@ natsTypeStar0 = cType 0 [] Nats (0, VStar 0) @?= Right ()
 nat1Inferred ∷ Assertion
 nat1Inferred = iType 0 [] (Nat 1) @?= Right (Omega, VNats)
 
-tests ∷ Test.Tasty.TestTree
-tests =
+--function has to be named test_ to be picked up by tasty.
+test_core ∷ Test.Tasty.TestTree
+test_core =
   testGroup
     "Core tests"
     [ testGroup
@@ -35,6 +33,5 @@ tests =
         [ testCase "Nats is of type * 0" natsTypeStar0
         , testCase "Inferred type of Nat 1 is (w, VNats)" nat1Inferred
         ]
-   -- , testGroup "Type-checker Properties" [testProperty "Quickcheck test" arith]
-   -- , testGroup "SmallCheck tests" [SC.testProperty "Negation" negation]
+    --, testGroup "Type-checker Properties" [testProperty "Quickcheck test" arith]
     ]

--- a/test/MainLangTests.hs
+++ b/test/MainLangTests.hs
@@ -1,0 +1,40 @@
+--Tests for the type checker and evaluator in Core/MainLang.hs.
+module MainLangTests where
+
+import           Juvix.Core.MainLang
+
+import           Prelude
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+--import           Test.Tasty.QuickCheck
+--import qualified Test.Tasty.SmallCheck as SC
+--import           Test.HUnit          (Assertion, (@?=))
+--import qualified Test.QuickCheck     as QC
+--property tests of type checker:
+--the term's inferred type equals to the input type
+--property test of evaluator:
+-- \x.x (any term) evaluates to (any term evaluated)
+{-lamProp :: CTerm -> Env -> Property
+lamProp cterm env = App (cEval (Lam Bound 0) env) cterm == cterm-}
+-- any constant term evaluates to itself
+--constProp :: CTerm -> Env -> Property
+--constProp
+natsTypeStar0 ∷ Assertion
+natsTypeStar0 = cType 0 [] Nats (0, VStar 0) @?= Right ()
+
+nat1Inferred ∷ Assertion
+nat1Inferred = iType 0 [] (Nat 1) @?= Right (Omega, VNats)
+
+tests ∷ Test.Tasty.TestTree
+tests =
+  testGroup
+    "Core tests"
+    [ testGroup
+        "Type-checker Units"
+        [ testCase "Nats is of type * 0" natsTypeStar0
+        , testCase "Inferred type of Nat 1 is (w, VNats)" nat1Inferred
+        ]
+   -- , testGroup "Type-checker Properties" [testProperty "Quickcheck test" arith]
+   -- , testGroup "SmallCheck tests" [SC.testProperty "Negation" negation]
+    ]

--- a/test/MainLangTests.hs
+++ b/test/MainLangTests.hs
@@ -3,10 +3,16 @@ module MainLangTests where
 
 import           Juvix.Core.MainLang
 
+import           Control.Monad.Except
+import           Numeric.Natural
 import           Prelude
+
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Gen
 
 --property tests of type checker:
 --the term's inferred type equals to the input type
@@ -15,8 +21,14 @@ import           Test.Tasty.QuickCheck
 {-lamProp :: CTerm -> Env -> Property
 lamProp cterm env = App (cEval (Lam Bound 0) env) cterm == cterm-}
 -- any constant term evaluates to itself
---constProp :: CTerm -> Env -> Property
---constProp
+constProp ∷ CTerm → Env → Bool
+constProp (Star i) env = cEval (Star i) env == VStar i
+constProp Nats env     = cEval Nats env == VNats
+  --constProp _ _          = True --Not testing non-const terms
+
+{-TODO need to combine generators to generate CTerms http://hackage.haskell.org/package/QuickCheck-2.13.2/docs/Test-QuickCheck-Gen.html
+instance Arbitrary CTerm where
+  arbitrary = CTerm -}
 natsTypeStar0 ∷ Assertion
 natsTypeStar0 = cType 0 [] Nats (0, VStar 0) @?= Right ()
 
@@ -33,5 +45,8 @@ test_core =
         [ testCase "Nats is of type * 0" natsTypeStar0
         , testCase "Inferred type of Nat 1 is (w, VNats)" nat1Inferred
         ]
+    , testGroup
+        "Evaluator Properties"
+        [testProperty "Constant terms should evaluate to themselves" constProp]
     --, testGroup "Type-checker Properties" [testProperty "Quickcheck test" arith]
     ]


### PR DESCRIPTION
Adding tests is WIP but the nat operations are added in the MainLang and Parser.  The operations use the operations of Haskell's Naturals.

TODOs:
- Still have to investigate why some operations are not parsed properly with the cterm parser. (All operations work fine with the iterm parser, the convITerm parser isn't converting the Ops that aren't the first listed Op in the iterm parser.) 
- Add unit and property tests for the parser. 
- Make this work with cEval.