### PR TITLE
Thealmarty/clean up warnings

### DIFF
--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -47,15 +47,15 @@ data CTerm
   deriving (Eq)
 
 instance Show CTerm where
-  show (Star n) = "* " ++ show n
+  show (Star n) = "* " <> show n
   show Nats = "Nat "
   show (Pi _usage varTy resultTy) =
-    "[Π] " ++ show varTy ++ "-> " ++ show resultTy
+    "[Π] " <> show varTy <> "-> " <> show resultTy
   show (Pm _usage first second) =
-    "([π] " ++ show first ++ ", " ++ show second ++ ") "
-  show (Pa _usage first second) = "/\\ " ++ show first ++ show second
-  show (NPm first second) = "\\/ " ++ show first ++ show second
-  show (Lam var) = "\\x. " ++ show var
+    "([π] " <> show first <> ", " <> show second <> ") "
+  show (Pa _usage first second) = "/\\ " <> show first <> show second
+  show (NPm first second) = "\\/ " <> show first <> show second
+  show (Lam var) = "\\x. " <> show var
   show (Conv term) --Conv should be invisible to users.
    = show term
 
@@ -69,12 +69,12 @@ data ITerm
   deriving (Eq)
 
 instance Show ITerm where
-  show (Bound i) = "Bound " ++ show i --to be improved
+  show (Bound i) = "Bound " <> show i --to be improved
   show (Free name) = show name --using derived show Name instance, to be improved
   show (Nat i) = show i
-  show (App f x) = show f ++ show x
+  show (App f x) = show f <> show x
   show (Ann pi theTerm theType) =
-    show theTerm ++ " : [" ++ show pi ++ "] " ++ show theType
+    show theTerm <> " : [" <> show pi <> "] " <> show theType
 
 data Name
   = Global String -- Global variables are represented by name thus type string
@@ -148,8 +148,8 @@ vapp (VLam f) v = f v
 vapp (VNeutral n) v = VNeutral (NApp n v)
 vapp x y =
   error
-    ("Application (vapp) error. Cannot apply \n" ++
-     show y ++ "\n to \n" ++ show x)
+    ("Application (vapp) error. Cannot apply \n" <>
+     show y <> "\n to \n" <> show x)
 
 --substitution function for checkable terms
 cSubst ∷ Natural → ITerm → CTerm → CTerm
@@ -203,16 +203,16 @@ boundfree _ii x        = Free x
 --error message for inferring/checking types
 errorMsg ∷ Natural → CTerm → Annotation → Annotation → String
 errorMsg binder cterm expectedT gotT =
-  "Type mismatched. \n" ++
-  show cterm ++
-  " \n (binder number " ++
-  show binder ++
-  ") is of type \n" ++
-  show (show (snd gotT)) ++
-  " , with " ++
-  show (fst gotT) ++
-  " usage.\n But the expected type is " ++
-  show (show (snd expectedT)) ++ " , with " ++ show (fst expectedT) ++ " usage."
+  "Type mismatched. \n" <>
+  show cterm <>
+  " \n (binder number " <>
+  show binder <>
+  ") is of type \n" <>
+  show (show (snd gotT)) <>
+  " , with " <>
+  show (fst gotT) <>
+  " usage.\n But the expected type is " <>
+  show (show (snd expectedT)) <> " , with " <> show (fst expectedT) <> " usage."
 
 --Type (and usage) checking
 type Result a = Either String a --when type checking fails, it throws an error.
@@ -228,10 +228,10 @@ cType _ii _g (Star n) ann = do
       unless
         (n < j)
         (throwError $
-         show (Star n) ++
-         " is of type * of a higher universe. But the expected type " ++
-         show (snd ann) ++ " is * of a equal or lower universe.")
-    _ -> throwError $ "* n is of type * but " ++ show (snd ann) ++ " is not *."
+         show (Star n) <>
+         " is of type * of a higher universe. But the expected type " <>
+         show (snd ann) <> " is * of a equal or lower universe.")
+    _ -> throwError $ "* n is of type * but " <> show (snd ann) <> " is not *."
 cType ii _g Nats ann =
   unless
     (SNat 0 == fst ann && quote0 (snd ann) == Star 0)
@@ -265,7 +265,7 @@ cType ii g (Lam s) ann =
         ((Local ii, (sig * pi, ty)) : g) --put s in the context with usage sig*pi
         (cSubst 0 (Free (Local ii)) s) --x (varType) in context S with sigma*pi usage.
         (sig, ty' (vfree (Local ii))) --is of type M (usage sigma) in context T
-    _ -> throwError $ show (snd ann) ++ " is not a function type but should be."
+    _ -> throwError $ show (snd ann) <> " is not a function type but should be."
 cType ii g (Conv e) ann = do
   ann' <- iType ii g e
   unless
@@ -273,12 +273,12 @@ cType ii g (Conv e) ann = do
     (throwError (errorMsg ii (Conv e) ann ann'))
 cType ii _g cterm theType =
   throwError
-    ("Type mismatch: \n" ++
-     show cterm ++
-     "\n (binder number " ++
-     show ii ++
-     ") is not a checkable term. Cannot check that it is of type " ++
-     show (snd theType) ++ " with " ++ show (fst theType) ++ " usage.")
+    ("Type mismatch: \n" <>
+     show cterm <>
+     "\n (binder number " <>
+     show ii <>
+     ") is not a checkable term. Cannot check that it is of type " <>
+     show (snd theType) <> " with " <> show (fst theType) <> " usage.")
 
 --inferable terms have type as output.
 iType0 ∷ Context → ITerm → Result Annotation
@@ -286,8 +286,8 @@ iType0 = iType 0
 
 iTypeErrorMsg ∷ Natural → Name → String
 iTypeErrorMsg ii x =
-  "Cannot find the type of \n" ++
-  show x ++ "\n (binder number " ++ show ii ++ ") in the environment."
+  "Cannot find the type of \n" <>
+  show x <> "\n (binder number " <> show ii <> ") in the environment."
 
 iType ∷ Natural → Context → ITerm → Result Annotation
 iType ii g (Free x) =
@@ -305,11 +305,11 @@ iType ii g (App m n) = do
       return (sig, resultTy (cEval n []))
     _ ->
       throwError
-        (show m ++
-         "\n (binder number " ++
-         show ii ++
-         ") is not a function type and thus \n" ++
-         show n ++ "\n cannot be applied to it.")
+        (show m <>
+         "\n (binder number " <>
+         show ii <>
+         ") is not a function type and thus \n" <>
+         show n <> "\n cannot be applied to it.")
 iType ii g (Ann pi theTerm theType)
   --TODO check theType is of type Star first? But we have stakable universes now.
   --cType ii g theType (0, VStar 0)

--- a/src/Juvix/Core/MainLang.hs
+++ b/src/Juvix/Core/MainLang.hs
@@ -81,9 +81,6 @@ data Value
   = VStar Natural
   | VNats
   | VPi Usage Value (Value → Value)
-  | VPm Usage Value (Value → Value)
-  | VPa Usage Value (Value → Value)
-  | VNPm Value Value
   | VLam (Value → Value)
   | VNeutral Neutral
   | VNat Natural
@@ -251,14 +248,6 @@ cType ii g (Conv e) ann = do
   unless
     (fst ann == fst ann' && quote0 (snd ann) == quote0 (snd ann'))
     (throwError (errorMsg ii (Conv e) ann ann'))
-cType ii _g cterm theType =
-  throwError
-    ("Type mismatch: \n" <>
-     show cterm <>
-     "\n (binder number " <>
-     show ii <>
-     ") is not a checkable term. Cannot check that it is of type " <>
-     show (snd theType) <> " with " <> show (fst theType) <> " usage.")
 
 --inferable terms have type as output.
 iType0 ∷ Context → ITerm → Result Annotation
@@ -270,6 +259,7 @@ iTypeErrorMsg ii x =
   show x <> "\n (binder number " <> show ii <> ") in the environment."
 
 iType ∷ Natural → Context → ITerm → Result Annotation
+--the type checker will never encounter a bound variable.
 iType ii g (Free x) =
   case lookup x g of
     Just ann -> return ann

--- a/src/Juvix/Core/Parser.hs
+++ b/src/Juvix/Core/Parser.hs
@@ -20,9 +20,6 @@ languageDef =
         [ "*" --sort
         , "Nat" --primitive Nat type
         , "[Π]" --function type
-        , "[π]" --dependent multiplicative conjunction type
-        , "/\\" --dependent additive conjunction type
-        , "\\/" --non-dependent multiplicative disjunction type
         , "Bound" --Bound var
         , "Free"
         , "Local"
@@ -79,29 +76,6 @@ piTerm = do
   input <- ctermOnly
   func <- ctermOnly
   return $ Pi pi input func
-
-pmTerm ∷ Parser CTerm
-pmTerm = do
-  reserved "[π]"
-  pm <- natw
-  input <- ctermOnly
-  func <- ctermOnly
-  return $ Pm pm input func
-
-paTerm ∷ Parser CTerm
-paTerm = do
-  reserved "/\\"
-  pa <- natw
-  input <- ctermOnly
-  func <- ctermOnly
-  return $ Pa pa input func
-
-npmTerm ∷ Parser CTerm
-npmTerm = do
-  reserved "\\/"
-  fst <- ctermOnly
-  snd <- ctermOnly
-  return $ NPm fst snd
 
 lamTerm ∷ Parser CTerm
 lamTerm = do
@@ -175,8 +149,7 @@ natTerm = Nat . fromInteger <$> natural
 
 cterm ∷ Parser CTerm
 cterm =
-  parens cterm <|> sortTerm <|> natTypeTerm <|> piTerm <|> pmTerm <|> paTerm <|>
-  npmTerm <|>
+  parens cterm <|> sortTerm <|> natTypeTerm <|> piTerm <|>
   lamTerm <|>
   convTerm <|>
   convITerm


### PR DESCRIPTION
- replaced all ```++``` with ```<>```. (In the future style changes like these may be done by a tool as per issue #117?)
- removed linear connectives for Styraconyx release.
- cleaned up warnings.