### PR TITLE
updated docker image to properly cover llvm

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -3,3 +3,11 @@ FROM fpco/stack-build:lts-13.30
 RUN ln -s /usr/bin/g++-7 /usr/bin/g++
 
 RUN git clone https://github.com/Z3Prover/z3.git && cd z3 && python scripts/mk_make.py && cd build && make && make install
+
+# Version info
+ENV LLVM_RELEASE 9
+ENV LLVM_VERSION 9.0.0
+
+# Install Clang and LLVM
+COPY llvm-install.sh .
+RUN ./llvm-install.sh

--- a/scripts/llvm-install.sh
+++ b/scripts/llvm-install.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+MIRROR="http://releases.llvm.org"
+
+# Determine architecture
+ARCH=$(dpkg --print-architecture)
+
+# Download
+echo "Downloading llvm-9.0.0.src.tar.xz"
+wget -nv -O "llvm-9.0.0.src.tar.xz"     "${MIRROR}/${LLVM_VERSION}/llvm-9.0.0.src.tar.xz"
+
+# Install
+# echo "Installing ${TARGET}"
+tar xf "llvm-9.0.0.src.tar.xz"
+
+cd ./llvm-9.0.0.src
+
+mkdir build
+cd build
+
+cmake ../
+
+# mkdir ../../bin/opt
+
+cmake --build .
+
+cmake --build . --target install
+
+cd ../..
+
+
+rm llvm-9.0.0.src.tar.xz
+rm -rf llvm-9.0.0.src
+# Cleanup
+# rm -rf "${DOWNLOAD_FILE}" "${TARGET}/" llvm-install.sh
+mkdir "juvix"

--- a/scripts/llvm-install.sh
+++ b/scripts/llvm-install.sh
@@ -3,12 +3,9 @@ set -eou pipefail
 
 MIRROR="http://releases.llvm.org"
 
-# Determine architecture
-ARCH=$(dpkg --print-architecture)
-
 # Download
 echo "Downloading llvm-9.0.0.src.tar.xz"
-wget -nv -O "llvm-9.0.0.src.tar.xz"     "${MIRROR}/${LLVM_VERSION}/llvm-9.0.0.src.tar.xz"
+wget -nv -O "llvm-9.0.0.src.tar.xz"     "${MIRROR}/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
 
 # Install
 # echo "Installing ${TARGET}"
@@ -21,17 +18,12 @@ cd build
 
 cmake ../
 
-# mkdir ../../bin/opt
-
 cmake --build .
 
 cmake --build . --target install
 
 cd ../..
 
-
+# Cleanup
 rm llvm-9.0.0.src.tar.xz
 rm -rf llvm-9.0.0.src
-# Cleanup
-# rm -rf "${DOWNLOAD_FILE}" "${TARGET}/" llvm-install.sh
-mkdir "juvix"

--- a/scripts/llvm-install.sh
+++ b/scripts/llvm-install.sh
@@ -4,26 +4,30 @@ set -eou pipefail
 MIRROR="http://releases.llvm.org"
 
 # Download
-echo "Downloading llvm-9.0.0.src.tar.xz"
-wget -nv -O "llvm-9.0.0.src.tar.xz"     "${MIRROR}/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
+echo "Downloading: llvm-${LLVM_VERSION}.src.tar.xz"
+wget -nv -O "llvm-${LLVM_VERSION}.src.tar.xz"     "${MIRROR}/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
 
-# Install
-# echo "Installing ${TARGET}"
-tar xf "llvm-9.0.0.src.tar.xz"
+# Extract
+echo "Extracting: llvm-${LLVM_VERSION}.src.tar.xz"
+tar xf "llvm-${LLVM_VERSION}.src.tar.xz"
 
-cd ./llvm-9.0.0.src
+cd ./llvm-${LLVM_VERSION}.src
 
 mkdir build
 cd build
 
+# Building
+echo "Building: llvm-${LLVM_VERSION}.src.tar.xz"
 cmake ../
 
 cmake --build .
 
+# Building
+echo "Installing llvm-${LLVM_VERSION}.src.tar.xz"
 cmake --build . --target install
 
 cd ../..
 
 # Cleanup
-rm llvm-9.0.0.src.tar.xz
-rm -rf llvm-9.0.0.src
+rm llvm-${LLVM_VERSION}.src.tar.xz
+rm -rf llvm-${LLVM_VERSION}.src


### PR DESCRIPTION
At some point rebuild, I forgot the last rm, so the current image being uploaded is about 34~ GB too big

This is after comitting the `rm -rf` changes to the image 