### PR TITLE
Thealmarty/add unit ty

### DIFF
--- a/app/Interactive.hs
+++ b/app/Interactive.hs
@@ -1,60 +1,60 @@
 module Interactive where
 
-import           Config
-import           Control.Monad.IO.Class
-import qualified Data.Text                             as T
-import qualified Juvix.Backends.Env                    as Env
-import qualified Juvix.Backends.Graph                  as Graph
-import qualified Juvix.Backends.Maps                   as Maps ()
-import qualified Juvix.Bohm                            as Bohm
-import qualified Juvix.Core                            as Core
-import qualified Juvix.Core.HR                         as Core
-import           Juvix.Core.Parameterisations.Naturals
-import qualified Juvix.EAC                             as EAC
-import qualified Juvix.Nets.Bohm                       as Bohm
-import           Options
-import           Prelude                               (String)
-import           Protolude
-import qualified System.Console.Haskeline              as H
-import           Text.PrettyPrint.ANSI.Leijen          hiding ((<>))
+import Config
+import Control.Monad.IO.Class
+import qualified Data.Text as T
+import qualified Juvix.Backends.Env as Env
+import qualified Juvix.Backends.Graph as Graph
+import qualified Juvix.Backends.Maps as Maps ()
+import qualified Juvix.Bohm as Bohm
+import qualified Juvix.Core as Core
+import qualified Juvix.Core.HR as Core
+import Juvix.Core.Parameterisations.Naturals
+import qualified Juvix.EAC as EAC
+import qualified Juvix.Nets.Bohm as Bohm
+import Options
+import Protolude
+import qualified System.Console.Haskeline as H
+import Text.PrettyPrint.ANSI.Leijen hiding ((<>))
+import Prelude (String)
 
-interactive :: Context -> Config -> IO ()
+interactive ∷ Context → Config → IO ()
 interactive ctx _ = do
-  func <- return $ \str -> return str
+  func ← return $ \str → return str
   H.runInputT (settings ctx) (mainLoop func)
 
-settings :: Context -> H.Settings IO
+settings ∷ Context → H.Settings IO
 settings ctx =
   H.Settings
-    { H.complete = H.completeFilename
-    , H.historyFile = Just (contextHomeDirectory ctx <> "/.jvxi_history")
-    , H.autoAddHistory = True
+    { H.complete = H.completeFilename,
+      H.historyFile = Just (contextHomeDirectory ctx <> "/.jvxi_history"),
+      H.autoAddHistory = True
     }
 
-mainLoop :: (String -> IO String) -> H.InputT IO ()
+mainLoop ∷ (String → IO String) → H.InputT IO ()
 mainLoop func = do
-  input <- H.getInputLine "jvxi >> "
+  input ← H.getInputLine "jvxi >> "
   case input of
-    Nothing -> return ()
-    Just i -> do
+    Nothing → return ()
+    Just i → do
       case i of
-        (':':special) -> handleSpecial special (mainLoop func)
-        inp -> do
+        (':' : special) → handleSpecial special (mainLoop func)
+        inp → do
           H.outputStrLn =<< liftIO (func inp)
           mainLoop func
 
-parseString :: String -> Maybe (Core.Term NatTy NatVal)
+parseString ∷ String → Maybe (Core.Term NatTy NatVal)
 parseString = Core.generateParser nat
 
-handleSpecial :: String -> H.InputT IO () -> H.InputT IO ()
+handleSpecial ∷ String → H.InputT IO () → H.InputT IO ()
 handleSpecial str cont = do
   case str of
-    "?" -> liftIO (putDoc specialsDoc) >> cont
-    "exit" -> return ()
-    "tutorial" -> do
+    "?" → liftIO (putDoc specialsDoc) >> cont
+    "exit" → return ()
+    "tutorial" → do
       H.outputStrLn "Interactive tutorial coming soon!"
       cont
-    'c':'p':' ':rest -> do
+    'c' : 'p' : ' ' : rest → do
       let parsed = parseString rest
       H.outputStrLn $ show parsed
       cont
@@ -81,26 +81,26 @@ handleSpecial str cont = do
         Nothing → return ()
       cont
     -}
-    'e':'p':' ':rest -> do
+    'e' : 'p' : ' ' : rest → do
       let parsed = EAC.parseEal rest
       case parsed of
-        Right r -> transformAndEvaluateEal True r
-        _       -> return ()
+        Right r → transformAndEvaluateEal True r
+        _ → return ()
       cont
-    'e':'q':' ':rest -> do
+    'e' : 'q' : ' ' : rest → do
       let parsed = EAC.parseEal rest
       case parsed of
-        Right r -> transformAndEvaluateEal False r
-        _       -> return ()
+        Right r → transformAndEvaluateEal False r
+        _ → return ()
       cont
-    'e':'e':' ':rest -> do
+    'e' : 'e' : ' ' : rest → do
       let parsed = EAC.parseEal rest
       H.outputStrLn $ show parsed
       case parsed of
-        Right r -> transformAndEvaluateEal True r
-        _       -> return ()
+        Right r → transformAndEvaluateEal True r
+        _ → return ()
       cont
-    _ -> H.outputStrLn "Unknown special command" >> cont
+    _ → H.outputStrLn "Unknown special command" >> cont
 
 {-
 eraseAndSolveCore ∷
@@ -111,11 +111,11 @@ eraseAndSolveCore cterm = do
   H.outputStrLn ("Inferred EAC term & type: " <> show res)
   pure res
 -}
-transformAndEvaluateEal :: Bool -> EAC.RPTO -> H.InputT IO ()
+transformAndEvaluateEal ∷ Bool → EAC.RPTO → H.InputT IO ()
 transformAndEvaluateEal debug term = do
   let bohm = EAC.ealToBohm term
   when debug $ H.outputStrLn ("Converted to BOHM: " <> show bohm)
-  let net :: Graph.FlipNet Bohm.Lang
+  let net ∷ Graph.FlipNet Bohm.Lang
       net = Bohm.astToNet bohm Bohm.defaultEnv
   when debug $ H.outputStrLn ("Translated to net: " <> show net)
   let reduced = Graph.runFlipNet (Bohm.reduceAll 1000000) net
@@ -126,31 +126,31 @@ transformAndEvaluateEal debug term = do
   when debug $ H.outputStrLn ("Reduction info: " <> show info)
   H.outputStrLn ("Read-back term: " <> show readback)
 
-specialsDoc :: Doc
+specialsDoc ∷ Doc
 specialsDoc =
   mconcat [line, mconcat (fmap (flip (<>) line . specialDoc) specials), line]
 
-specialDoc :: Special -> Doc
+specialDoc ∷ Special → Doc
 specialDoc (Special command helpDesc) =
   text $ T.unpack $ mconcat [":", command, " - ", helpDesc]
 
-specials :: [Special]
+specials ∷ [Special]
 specials =
-  [ Special "cp [term]" "Parse a Juvix Core term"
-  , Special "ct [term}" "Parse, typecheck, & evaluate a Juvix Core term"
-  , Special
+  [ Special "cp [term]" "Parse a Juvix Core term",
+    Special "ct [term}" "Parse, typecheck, & evaluate a Juvix Core term",
+    Special
       "ce [term"
-      "Parse a Juvix Core term, translate to EAC, solve constraints, evaluate & read-back"
-  , Special "ep [term]" "Parse an EAC term"
-  , Special "ee [term]" "Parse an EAC term, evaluate & read-back"
-  , Special "eq [term]" "Parse an EAC term, evaluate & read-back quietly"
-  , Special "tutorial" "Embark upon an interactive tutorial"
-  , Special "?" "Show this help message"
-  , Special "exit" "Quit interactive mode"
+      "Parse a Juvix Core term, translate to EAC, solve constraints, evaluate & read-back",
+    Special "ep [term]" "Parse an EAC term",
+    Special "ee [term]" "Parse an EAC term, evaluate & read-back",
+    Special "eq [term]" "Parse an EAC term, evaluate & read-back quietly",
+    Special "tutorial" "Embark upon an interactive tutorial",
+    Special "?" "Show this help message",
+    Special "exit" "Quit interactive mode"
   ]
 
-data Special =
-  Special
-    { specialCommand  :: Text
-    , specialHelpDesc :: Text
-    }
+data Special
+  = Special
+      { specialCommand ∷ Text,
+        specialHelpDesc ∷ Text
+      }

--- a/app/Interactive.hs
+++ b/app/Interactive.hs
@@ -1,60 +1,60 @@
 module Interactive where
 
-import Config
-import Control.Monad.IO.Class
-import qualified Data.Text as T
-import qualified Juvix.Backends.Env as Env
-import qualified Juvix.Backends.Graph as Graph
-import qualified Juvix.Backends.Maps as Maps ()
-import qualified Juvix.Bohm as Bohm
-import qualified Juvix.Core as Core
-import qualified Juvix.Core.HR as Core
-import Juvix.Core.Parameterisations.Naturals
-import qualified Juvix.EAC as EAC
-import qualified Juvix.Nets.Bohm as Bohm
-import Options
-import Protolude
-import qualified System.Console.Haskeline as H
-import Text.PrettyPrint.ANSI.Leijen hiding ((<>))
-import Prelude (String)
+import           Config
+import           Control.Monad.IO.Class
+import qualified Data.Text                             as T
+import qualified Juvix.Backends.Env                    as Env
+import qualified Juvix.Backends.Graph                  as Graph
+import qualified Juvix.Backends.Maps                   as Maps ()
+import qualified Juvix.Bohm                            as Bohm
+import qualified Juvix.Core                            as Core
+import qualified Juvix.Core.HR                         as Core
+import           Juvix.Core.Parameterisations.Naturals
+import qualified Juvix.EAC                             as EAC
+import qualified Juvix.Nets.Bohm                       as Bohm
+import           Options
+import           Prelude                               (String)
+import           Protolude
+import qualified System.Console.Haskeline              as H
+import           Text.PrettyPrint.ANSI.Leijen          hiding ((<>))
 
-interactive ∷ Context → Config → IO ()
+interactive :: Context -> Config -> IO ()
 interactive ctx _ = do
-  func ← return $ \str → return str
+  func <- return $ \str -> return str
   H.runInputT (settings ctx) (mainLoop func)
 
-settings ∷ Context → H.Settings IO
+settings :: Context -> H.Settings IO
 settings ctx =
   H.Settings
-    { H.complete = H.completeFilename,
-      H.historyFile = Just (contextHomeDirectory ctx <> "/.jvxi_history"),
-      H.autoAddHistory = True
+    { H.complete = H.completeFilename
+    , H.historyFile = Just (contextHomeDirectory ctx <> "/.jvxi_history")
+    , H.autoAddHistory = True
     }
 
-mainLoop ∷ (String → IO String) → H.InputT IO ()
+mainLoop :: (String -> IO String) -> H.InputT IO ()
 mainLoop func = do
-  input ← H.getInputLine "jvxi >> "
+  input <- H.getInputLine "jvxi >> "
   case input of
-    Nothing → return ()
-    Just i → do
+    Nothing -> return ()
+    Just i -> do
       case i of
-        (':' : special) → handleSpecial special (mainLoop func)
-        inp → do
+        (':':special) -> handleSpecial special (mainLoop func)
+        inp -> do
           H.outputStrLn =<< liftIO (func inp)
           mainLoop func
 
-parseString ∷ String → Maybe (Core.Term NatTy NatVal)
-parseString = Core.generateParser naturals
+parseString :: String -> Maybe (Core.Term NatTy NatVal)
+parseString = Core.generateParser nat
 
-handleSpecial ∷ String → H.InputT IO () → H.InputT IO ()
+handleSpecial :: String -> H.InputT IO () -> H.InputT IO ()
 handleSpecial str cont = do
   case str of
-    "?" → liftIO (putDoc specialsDoc) >> cont
-    "exit" → return ()
-    "tutorial" → do
+    "?" -> liftIO (putDoc specialsDoc) >> cont
+    "exit" -> return ()
+    "tutorial" -> do
       H.outputStrLn "Interactive tutorial coming soon!"
       cont
-    'c' : 'p' : ' ' : rest → do
+    'c':'p':' ':rest -> do
       let parsed = parseString rest
       H.outputStrLn $ show parsed
       cont
@@ -81,26 +81,26 @@ handleSpecial str cont = do
         Nothing → return ()
       cont
     -}
-    'e' : 'p' : ' ' : rest → do
+    'e':'p':' ':rest -> do
       let parsed = EAC.parseEal rest
       case parsed of
-        Right r → transformAndEvaluateEal True r
-        _ → return ()
+        Right r -> transformAndEvaluateEal True r
+        _       -> return ()
       cont
-    'e' : 'q' : ' ' : rest → do
+    'e':'q':' ':rest -> do
       let parsed = EAC.parseEal rest
       case parsed of
-        Right r → transformAndEvaluateEal False r
-        _ → return ()
+        Right r -> transformAndEvaluateEal False r
+        _       -> return ()
       cont
-    'e' : 'e' : ' ' : rest → do
+    'e':'e':' ':rest -> do
       let parsed = EAC.parseEal rest
       H.outputStrLn $ show parsed
       case parsed of
-        Right r → transformAndEvaluateEal True r
-        _ → return ()
+        Right r -> transformAndEvaluateEal True r
+        _       -> return ()
       cont
-    _ → H.outputStrLn "Unknown special command" >> cont
+    _ -> H.outputStrLn "Unknown special command" >> cont
 
 {-
 eraseAndSolveCore ∷
@@ -111,12 +111,11 @@ eraseAndSolveCore cterm = do
   H.outputStrLn ("Inferred EAC term & type: " <> show res)
   pure res
 -}
-
-transformAndEvaluateEal ∷ Bool → EAC.RPTO → H.InputT IO ()
+transformAndEvaluateEal :: Bool -> EAC.RPTO -> H.InputT IO ()
 transformAndEvaluateEal debug term = do
   let bohm = EAC.ealToBohm term
   when debug $ H.outputStrLn ("Converted to BOHM: " <> show bohm)
-  let net ∷ Graph.FlipNet Bohm.Lang
+  let net :: Graph.FlipNet Bohm.Lang
       net = Bohm.astToNet bohm Bohm.defaultEnv
   when debug $ H.outputStrLn ("Translated to net: " <> show net)
   let reduced = Graph.runFlipNet (Bohm.reduceAll 1000000) net
@@ -127,35 +126,31 @@ transformAndEvaluateEal debug term = do
   when debug $ H.outputStrLn ("Reduction info: " <> show info)
   H.outputStrLn ("Read-back term: " <> show readback)
 
-specialsDoc ∷ Doc
+specialsDoc :: Doc
 specialsDoc =
-  mconcat
-    [ line,
-      mconcat (fmap (flip (<>) line . specialDoc) specials),
-      line
-    ]
+  mconcat [line, mconcat (fmap (flip (<>) line . specialDoc) specials), line]
 
-specialDoc ∷ Special → Doc
+specialDoc :: Special -> Doc
 specialDoc (Special command helpDesc) =
   text $ T.unpack $ mconcat [":", command, " - ", helpDesc]
 
-specials ∷ [Special]
+specials :: [Special]
 specials =
-  [ Special "cp [term]" "Parse a Juvix Core term",
-    Special "ct [term}" "Parse, typecheck, & evaluate a Juvix Core term",
-    Special
+  [ Special "cp [term]" "Parse a Juvix Core term"
+  , Special "ct [term}" "Parse, typecheck, & evaluate a Juvix Core term"
+  , Special
       "ce [term"
-      "Parse a Juvix Core term, translate to EAC, solve constraints, evaluate & read-back",
-    Special "ep [term]" "Parse an EAC term",
-    Special "ee [term]" "Parse an EAC term, evaluate & read-back",
-    Special "eq [term]" "Parse an EAC term, evaluate & read-back quietly",
-    Special "tutorial" "Embark upon an interactive tutorial",
-    Special "?" "Show this help message",
-    Special "exit" "Quit interactive mode"
+      "Parse a Juvix Core term, translate to EAC, solve constraints, evaluate & read-back"
+  , Special "ep [term]" "Parse an EAC term"
+  , Special "ee [term]" "Parse an EAC term, evaluate & read-back"
+  , Special "eq [term]" "Parse an EAC term, evaluate & read-back quietly"
+  , Special "tutorial" "Embark upon an interactive tutorial"
+  , Special "?" "Show this help message"
+  , Special "exit" "Quit interactive mode"
   ]
 
-data Special
-  = Special
-      { specialCommand ∷ Text,
-        specialHelpDesc ∷ Text
-      }
+data Special =
+  Special
+    { specialCommand  :: Text
+    , specialHelpDesc :: Text
+    }

--- a/package.yaml
+++ b/package.yaml
@@ -73,6 +73,7 @@ library:
     - Juvix.Core.IR
     - Juvix.Core.Erasure
     - Juvix.Core.Usage
+    - Juvix.Core.Types
     - Juvix.Core.Parameterisations.Naturals
     - Juvix.Core.Parameterisations.Unit
     - Juvix.EAC
@@ -106,7 +107,6 @@ library:
     - Juvix.NodeInterface
     - Juvix.Utility.Helper
     - Juvix.Utility.PrettyPrint
-    - Juvix.Core.Types
     - Juvix.Core.Translate
     - Juvix.Core.Utility
     - Juvix.Core.IR.Types

--- a/package.yaml
+++ b/package.yaml
@@ -74,6 +74,7 @@ library:
     - Juvix.Core.Erasure
     - Juvix.Core.Usage
     - Juvix.Core.Parameterisations.Naturals
+    - Juvix.Core.Parameterisations.Unit
     - Juvix.EAC
     - Juvix.EAC.Check
     - Juvix.EAC.EAC

--- a/src/Juvix/Core/HR/Parser.hs
+++ b/src/Juvix/Core/HR/Parser.hs
@@ -1,134 +1,137 @@
+{-# LANGUAGE ExplicitForAll #-}
+
 module Juvix.Core.HR.Parser where
 
-import Data.Functor.Identity
-import Juvix.Core.HR.Types
-import Juvix.Core.Types
-import Juvix.Core.Usage
-import Juvix.Library hiding ((<|>), try)
-import Text.Parsec hiding (try)
-import Text.ParserCombinators.Parsec
-import Text.ParserCombinators.Parsec.Expr
-import Text.ParserCombinators.Parsec.Language hiding (reservedNames, reservedOpNames)
-import qualified Text.ParserCombinators.Parsec.Token as Token
-import Prelude (String)
+import           Data.Functor.Identity
+import           Juvix.Core.HR.Types
+import           Juvix.Core.Types
+import           Juvix.Core.Usage
+import           Juvix.Library                          hiding (try, (<|>))
+import           Prelude                                (String)
+import           Text.Parsec                            hiding (try)
+import           Text.ParserCombinators.Parsec
+import           Text.ParserCombinators.Parsec.Expr
+import           Text.ParserCombinators.Parsec.Language hiding (reservedNames,
+                                                         reservedOpNames)
+import qualified Text.ParserCombinators.Parsec.Token    as Token
 
-baseReservedNames ∷ [String]
+baseReservedNames :: [String]
 baseReservedNames =
-  [ "*", -- sort
-    "[Π]", -- function type
-    "w" -- omega
+  [ "*" -- sort
+  , "[Π]" -- function type
+  , "w" -- omega
   ]
 
-baseReservedOpNames ∷ [String]
+baseReservedOpNames :: [String]
 baseReservedOpNames =
-  [ "\\", -- lambda
-    "@", -- TODO: remove me, necessary for annotation parsing at the moment
-    ":", -- type & usage annotation
-    "->" -- arrow
+  [ "\\" -- lambda
+  , "@" -- TODO: remove me, necessary for annotation parsing at the moment
+  , ":" -- type & usage annotation
+  , "->" -- arrow
   ]
 
-generateParser ∷ ∀ primTy primVal. Parameterisation primTy primVal → (String → Maybe (Term primTy primVal))
+generateParser ::
+     forall primTy primVal.
+     Parameterisation primTy primVal
+  -> (String -> Maybe (Term primTy primVal))
 generateParser parameterisation =
-  let opNames ∷ [String]
+  let opNames :: [String]
       opNames = baseReservedOpNames <> reservedOpNames parameterisation
-      languageDef ∷ GenLanguageDef String u Identity
+      languageDef :: GenLanguageDef String u Identity
       languageDef =
         emptyDef
-          { Token.commentStart = "/*",
-            Token.commentEnd = "*/",
-            Token.commentLine = "//",
-            Token.identStart = letter,
-            Token.identLetter = alphaNum,
-            Token.reservedNames = baseReservedNames <> reservedNames parameterisation,
-            Token.reservedOpNames = opNames
+          { Token.commentStart = "/*"
+          , Token.commentEnd = "*/"
+          , Token.commentLine = "//"
+          , Token.identStart = letter
+          , Token.identLetter = alphaNum
+          , Token.reservedNames =
+              baseReservedNames <> reservedNames parameterisation
+          , Token.reservedOpNames = opNames
           }
-      ops ∷ [[Operator Char () (Elim primTy primVal)]]
+      ops :: [[Operator Char () (Elim primTy primVal)]]
       ops = [[Infix appl AssocLeft]]
-      appl ∷ Parser ((Elim primTy primVal) → (Elim primTy primVal) → (Elim primTy primVal))
+      appl ::
+           Parser (Elim primTy primVal -> Elim primTy primVal -> Elim primTy primVal)
       appl = do
         whiteSpace
         notFollowedBy (choice (map reservedOp opNames))
-        pure (\f x → App f (Elim x))
-      lexer ∷ Token.GenTokenParser String u Identity
+        pure (\f x -> App f (Elim x))
+      lexer :: Token.GenTokenParser String u Identity
       lexer = Token.makeTokenParser languageDef
-      identifier ∷ Parser String
+      identifier :: Parser String
       identifier = Token.identifier lexer
-      reserved ∷ String → Parser ()
+      reserved :: String -> Parser ()
       reserved = Token.reserved lexer
-      reservedOp ∷ String → Parser ()
+      reservedOp :: String -> Parser ()
       reservedOp = Token.reservedOp lexer
-      parens ∷ Parser a → Parser a
+      parens :: Parser a -> Parser a
       parens = Token.parens lexer
-      natural ∷ Parser Integer
+      natural :: Parser Integer
       natural = Token.natural lexer
-      whiteSpace ∷ Parser ()
+      whiteSpace :: Parser ()
       whiteSpace = Token.whiteSpace lexer
-      usage ∷ Parser Usage
-      usage =
-        ( reserved "w"
-            >> return Omega
-        )
-          <|> SNat . fromInteger <$> natural
-      primTyTerm ∷ Parser (Term primTy primVal)
+      usage :: Parser Usage
+      usage = (reserved "w" >> return Omega) <|> SNat . fromInteger <$> natural
+      primTyTerm :: Parser (Term primTy primVal)
       primTyTerm = PrimTy |<< parseTy parameterisation lexer
-      sortTerm ∷ Parser (Term primTy primVal)
+      sortTerm :: Parser (Term primTy primVal)
       sortTerm = do
         reserved "*"
-        n ← natural
+        n <- natural
         return $ Star (fromInteger n)
-      piTerm ∷ Parser (Term primTy primVal)
+      piTerm :: Parser (Term primTy primVal)
       piTerm = do
         reserved "[Π]"
-        pi ← usage
-        input ← term
-        func ← term
+        pi <- usage
+        input <- term
+        func <- term
         return $ Pi pi input func
-      lamTerm ∷ Parser (Term primTy primVal)
+      lamTerm :: Parser (Term primTy primVal)
       lamTerm = do
         reservedOp "\\"
-        binder ← binder
+        binder <- binder
         reservedOp "->"
-        func ← term
+        func <- term
         return $ Lam binder func
-      binder ∷ Parser Symbol
+      binder :: Parser Symbol
       binder = intern |<< identifier
-      term ∷ Parser (Term primTy primVal)
+      term :: Parser (Term primTy primVal)
       term = try termOnly <|> elimTerm
-      termOnly ∷ Parser (Term primTy primVal)
+      termOnly :: Parser (Term primTy primVal)
       termOnly =
         parens termOnly <|> primTyTerm <|> sortTerm <|> piTerm <|> lamTerm
-      elimTerm ∷ Parser (Term primTy primVal)
+      elimTerm :: Parser (Term primTy primVal)
       elimTerm = do
-        elim ← elim
+        elim <- elim
         pure (Elim elim)
-      primElim ∷ Parser (Elim primTy primVal)
+      primElim :: Parser (Elim primTy primVal)
       primElim = Prim |<< parseVal parameterisation lexer
-      annElim ∷ Parser (Elim primTy primVal)
+      annElim :: Parser (Elim primTy primVal)
       annElim = do
         reservedOp "@"
-        theTerm ← termOnly
+        theTerm <- termOnly
         reservedOp ":"
-        pi ← usage
-        theType ← term
+        pi <- usage
+        theType <- term
         pure (Ann pi theTerm theType)
-      varElim ∷ Parser (Elim primTy primVal)
+      varElim :: Parser (Elim primTy primVal)
       varElim = Var |<< binder
-      elim ∷ Parser (Elim primTy primVal)
+      elim :: Parser (Elim primTy primVal)
       elim = buildExpressionParser ops elim'
-      elim' ∷ Parser (Elim primTy primVal)
-      elim' =
-        parens elim <|> try primElim <|> annElim <|> varElim
-      parseWhole ∷ Parser a → Parser a
+      elim' :: Parser (Elim primTy primVal)
+      elim' = parens elim <|> try primElim <|> annElim <|> varElim
+      parseWhole :: Parser a -> Parser a
       parseWhole p = do
         whiteSpace
-        t ← p
+        t <- p
         whiteSpace
         eof
         return t
    in parseString' (parseWhole term)
 
-parseString' ∷ Parser a → String → Maybe a
+parseString' :: Parser a -> String -> Maybe a
 parseString' p str =
   case parse p "" str of
-    Left _ → Nothing
-    Right r → Just r
+    Left _  -> Nothing
+    Right r -> Just r

--- a/src/Juvix/Core/HR/Parser.hs
+++ b/src/Juvix/Core/HR/Parser.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ExplicitForAll #-}
-
 module Juvix.Core.HR.Parser where
 
 import Data.Functor.Identity

--- a/src/Juvix/Core/HR/Parser.hs
+++ b/src/Juvix/Core/HR/Parser.hs
@@ -2,136 +2,138 @@
 
 module Juvix.Core.HR.Parser where
 
-import           Data.Functor.Identity
-import           Juvix.Core.HR.Types
-import           Juvix.Core.Types
-import           Juvix.Core.Usage
-import           Juvix.Library                          hiding (try, (<|>))
-import           Prelude                                (String)
-import           Text.Parsec                            hiding (try)
-import           Text.ParserCombinators.Parsec
-import           Text.ParserCombinators.Parsec.Expr
-import           Text.ParserCombinators.Parsec.Language hiding (reservedNames,
-                                                         reservedOpNames)
-import qualified Text.ParserCombinators.Parsec.Token    as Token
+import Data.Functor.Identity
+import Juvix.Core.HR.Types
+import Juvix.Core.Types
+import Juvix.Core.Usage
+import Juvix.Library hiding ((<|>), try)
+import Text.Parsec hiding (try)
+import Text.ParserCombinators.Parsec
+import Text.ParserCombinators.Parsec.Expr
+import Text.ParserCombinators.Parsec.Language hiding
+  ( reservedNames,
+    reservedOpNames,
+  )
+import qualified Text.ParserCombinators.Parsec.Token as Token
+import Prelude (String)
 
-baseReservedNames :: [String]
+baseReservedNames ∷ [String]
 baseReservedNames =
-  [ "*" -- sort
-  , "[Π]" -- function type
-  , "w" -- omega
+  [ "*", -- sort
+    "[Π]", -- function type
+    "w" -- omega
   ]
 
-baseReservedOpNames :: [String]
+baseReservedOpNames ∷ [String]
 baseReservedOpNames =
-  [ "\\" -- lambda
-  , "@" -- TODO: remove me, necessary for annotation parsing at the moment
-  , ":" -- type & usage annotation
-  , "->" -- arrow
+  [ "\\", -- lambda
+    "@", -- TODO: remove me, necessary for annotation parsing at the moment
+    ":", -- type & usage annotation
+    "->" -- arrow
   ]
 
-generateParser ::
-     forall primTy primVal.
-     Parameterisation primTy primVal
-  -> (String -> Maybe (Term primTy primVal))
+generateParser ∷
+  ∀ primTy primVal.
+  Parameterisation primTy primVal →
+  (String → Maybe (Term primTy primVal))
 generateParser parameterisation =
-  let opNames :: [String]
+  let opNames ∷ [String]
       opNames = baseReservedOpNames <> reservedOpNames parameterisation
-      languageDef :: GenLanguageDef String u Identity
+      languageDef ∷ GenLanguageDef String u Identity
       languageDef =
         emptyDef
-          { Token.commentStart = "/*"
-          , Token.commentEnd = "*/"
-          , Token.commentLine = "//"
-          , Token.identStart = letter
-          , Token.identLetter = alphaNum
-          , Token.reservedNames =
-              baseReservedNames <> reservedNames parameterisation
-          , Token.reservedOpNames = opNames
+          { Token.commentStart = "/*",
+            Token.commentEnd = "*/",
+            Token.commentLine = "//",
+            Token.identStart = letter,
+            Token.identLetter = alphaNum,
+            Token.reservedNames =
+              baseReservedNames <> reservedNames parameterisation,
+            Token.reservedOpNames = opNames
           }
-      ops :: [[Operator Char () (Elim primTy primVal)]]
+      ops ∷ [[Operator Char () (Elim primTy primVal)]]
       ops = [[Infix appl AssocLeft]]
-      appl ::
-           Parser (Elim primTy primVal -> Elim primTy primVal -> Elim primTy primVal)
+      appl ∷
+        Parser (Elim primTy primVal → Elim primTy primVal → Elim primTy primVal)
       appl = do
         whiteSpace
         notFollowedBy (choice (map reservedOp opNames))
-        pure (\f x -> App f (Elim x))
-      lexer :: Token.GenTokenParser String u Identity
+        pure (\f x → App f (Elim x))
+      lexer ∷ Token.GenTokenParser String u Identity
       lexer = Token.makeTokenParser languageDef
-      identifier :: Parser String
+      identifier ∷ Parser String
       identifier = Token.identifier lexer
-      reserved :: String -> Parser ()
+      reserved ∷ String → Parser ()
       reserved = Token.reserved lexer
-      reservedOp :: String -> Parser ()
+      reservedOp ∷ String → Parser ()
       reservedOp = Token.reservedOp lexer
-      parens :: Parser a -> Parser a
+      parens ∷ Parser a → Parser a
       parens = Token.parens lexer
-      natural :: Parser Integer
+      natural ∷ Parser Integer
       natural = Token.natural lexer
-      whiteSpace :: Parser ()
+      whiteSpace ∷ Parser ()
       whiteSpace = Token.whiteSpace lexer
-      usage :: Parser Usage
+      usage ∷ Parser Usage
       usage = (reserved "w" >> return Omega) <|> SNat . fromInteger <$> natural
-      primTyTerm :: Parser (Term primTy primVal)
+      primTyTerm ∷ Parser (Term primTy primVal)
       primTyTerm = PrimTy |<< parseTy parameterisation lexer
-      sortTerm :: Parser (Term primTy primVal)
+      sortTerm ∷ Parser (Term primTy primVal)
       sortTerm = do
         reserved "*"
-        n <- natural
+        n ← natural
         return $ Star (fromInteger n)
-      piTerm :: Parser (Term primTy primVal)
+      piTerm ∷ Parser (Term primTy primVal)
       piTerm = do
         reserved "[Π]"
-        pi <- usage
-        input <- term
-        func <- term
+        pi ← usage
+        input ← term
+        func ← term
         return $ Pi pi input func
-      lamTerm :: Parser (Term primTy primVal)
+      lamTerm ∷ Parser (Term primTy primVal)
       lamTerm = do
         reservedOp "\\"
-        binder <- binder
+        binder ← binder
         reservedOp "->"
-        func <- term
+        func ← term
         return $ Lam binder func
-      binder :: Parser Symbol
+      binder ∷ Parser Symbol
       binder = intern |<< identifier
-      term :: Parser (Term primTy primVal)
+      term ∷ Parser (Term primTy primVal)
       term = try termOnly <|> elimTerm
-      termOnly :: Parser (Term primTy primVal)
+      termOnly ∷ Parser (Term primTy primVal)
       termOnly =
         parens termOnly <|> primTyTerm <|> sortTerm <|> piTerm <|> lamTerm
-      elimTerm :: Parser (Term primTy primVal)
+      elimTerm ∷ Parser (Term primTy primVal)
       elimTerm = do
-        elim <- elim
+        elim ← elim
         pure (Elim elim)
-      primElim :: Parser (Elim primTy primVal)
+      primElim ∷ Parser (Elim primTy primVal)
       primElim = Prim |<< parseVal parameterisation lexer
-      annElim :: Parser (Elim primTy primVal)
+      annElim ∷ Parser (Elim primTy primVal)
       annElim = do
         reservedOp "@"
-        theTerm <- termOnly
+        theTerm ← termOnly
         reservedOp ":"
-        pi <- usage
-        theType <- term
+        pi ← usage
+        theType ← term
         pure (Ann pi theTerm theType)
-      varElim :: Parser (Elim primTy primVal)
+      varElim ∷ Parser (Elim primTy primVal)
       varElim = Var |<< binder
-      elim :: Parser (Elim primTy primVal)
+      elim ∷ Parser (Elim primTy primVal)
       elim = buildExpressionParser ops elim'
-      elim' :: Parser (Elim primTy primVal)
+      elim' ∷ Parser (Elim primTy primVal)
       elim' = parens elim <|> try primElim <|> annElim <|> varElim
-      parseWhole :: Parser a -> Parser a
+      parseWhole ∷ Parser a → Parser a
       parseWhole p = do
         whiteSpace
-        t <- p
+        t ← p
         whiteSpace
         eof
         return t
    in parseString' (parseWhole term)
 
-parseString' :: Parser a -> String -> Maybe a
+parseString' ∷ Parser a → String → Maybe a
 parseString' p str =
   case parse p "" str of
-    Left _  -> Nothing
-    Right r -> Just r
+    Left _ → Nothing
+    Right r → Just r

--- a/src/Juvix/Core/IR/Typechecker.hs
+++ b/src/Juvix/Core/IR/Typechecker.hs
@@ -3,9 +3,9 @@ module Juvix.Core.IR.Typechecker where
 import Control.Lens ((^?), ix)
 import Control.Monad.Except (throwError)
 import Juvix.Core.IR.Types
-import Juvix.Core.Types
 import Juvix.Core.Parameterisations.Naturals
 import Juvix.Core.Parameterisations.Unit
+import Juvix.Core.Types
 import Juvix.Core.Usage
 import Juvix.Library hiding (show)
 import Prelude (Show (..), String, error, lookup)

--- a/src/Juvix/Core/IR/Typechecker.hs
+++ b/src/Juvix/Core/IR/Typechecker.hs
@@ -4,6 +4,8 @@ import Control.Lens ((^?), ix)
 import Control.Monad.Except (throwError)
 import Juvix.Core.IR.Types
 import Juvix.Core.Types
+import Juvix.Core.Parameterisations.Naturals
+import Juvix.Core.Parameterisations.Unit
 import Juvix.Core.Usage
 import Juvix.Library hiding (show)
 import Prelude (Show (..), String, error, lookup)
@@ -54,7 +56,7 @@ vapp ∷
 vapp _ (VLam f) v = f v
 vapp _ (VNeutral n) v = VNeutral (NApp n v)
 vapp param (VPrim x) (VPrim y) =
-  case apply param x y of
+  case Juvix.Core.Types.apply param x y of
     Just v → VPrim v
     Nothing →
       error
@@ -214,7 +216,7 @@ iType _ ii g (Free x) =
 iType p _ii _g (Prim prim) =
   let arrow [x] = VPrimTy x
       arrow (x : xs) = VPi Omega (VPrimTy x) (const (arrow xs))
-   in case typeOf p arrow prim of
+   in case Juvix.Core.Types.typeOf p arrow prim of
         Right a → return (Omega, VPrimTy a)
         Left f → return (Omega, f)
 -- App, function M applies to N (Elimination rule of dependent function types)

--- a/src/Juvix/Core/Parameterisations/Naturals.hs
+++ b/src/Juvix/Core/Parameterisations/Naturals.hs
@@ -1,14 +1,18 @@
+{-# LANGUAGE ExplicitForAll #-}
+
 module Juvix.Core.Parameterisations.Naturals where
 
-import Juvix.Core.Types hiding (apply, parseTy, parseVal, reservedNames, reservedOpNames, typeOf)
-import Juvix.Library hiding ((<|>))
-import Text.ParserCombinators.Parsec
+import           Juvix.Core.Types                    hiding (apply, parseTy,
+                                                      parseVal, reservedNames,
+                                                      reservedOpNames, typeOf)
+import           Juvix.Library                       hiding ((<|>))
+import           Prelude                             (String)
+import           Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
-import Prelude (String)
 
 -- k: primitive type: naturals
-data NatTy
-  = Nat
+data NatTy =
+  Nat
   deriving (Show, Eq)
 
 -- c: primitive constant and f: functions
@@ -20,47 +24,49 @@ data NatVal
   | Curried NatVal Natural
   deriving (Show, Eq)
 
-typeOf ∷ ∀ a. ([NatTy] → a) → NatVal → Either a NatTy
-typeOf _ (Natural _) = Right Nat
+typeOf :: forall a. ([NatTy] -> a) -> NatVal -> Either a NatTy
+typeOf _ (Natural _)       = Right Nat
 typeOf arrow (Curried _ _) = Left $ arrow [Nat, Nat]
-typeOf arrow Add = Left $ arrow [Nat, Nat, Nat]
-typeOf arrow Sub = Left $ arrow [Nat, Nat, Nat]
-typeOf arrow Mul = Left $ arrow [Nat, Nat, Nat]
+typeOf arrow Add           = Left $ arrow [Nat, Nat, Nat]
+typeOf arrow Sub           = Left $ arrow [Nat, Nat, Nat]
+typeOf arrow Mul           = Left $ arrow [Nat, Nat, Nat]
 
-apply ∷ NatVal → NatVal → Maybe NatVal
-apply Add (Natural x) = pure (Curried Add x)
-apply Sub (Natural x) = pure (Curried Sub x)
-apply Mul (Natural x) = pure (Curried Mul x)
+apply :: NatVal -> NatVal -> Maybe NatVal
+apply Add (Natural x)             = pure (Curried Add x)
+apply Sub (Natural x)             = pure (Curried Sub x)
+apply Mul (Natural x)             = pure (Curried Mul x)
 apply (Curried Add x) (Natural y) = pure (Natural (x + y))
 apply (Curried Sub x) (Natural y) = pure (Natural (x - y))
 apply (Curried Mul x) (Natural y) = pure (Natural (x * y))
-apply _ _ = Nothing
+apply _ _                         = Nothing
 
-parseTy ∷ Token.GenTokenParser String () Identity → Parser NatTy
+parseTy :: Token.GenTokenParser String () Identity -> Parser NatTy
 parseTy lexer = do
   Token.reserved lexer "Nat"
   pure Nat
 
-parseVal ∷ Token.GenTokenParser String () Identity → Parser NatVal
-parseVal lexer = parseNat lexer <|> parseAdd lexer <|> parseSub lexer <|> parseMul lexer
+parseVal :: Token.GenTokenParser String () Identity -> Parser NatVal
+parseVal lexer =
+  parseNat lexer <|> parseAdd lexer <|> parseSub lexer <|> parseMul lexer
 
-parseNat ∷ Token.GenTokenParser String () Identity → Parser NatVal
+parseNat :: Token.GenTokenParser String () Identity -> Parser NatVal
 parseNat lexer = Natural . fromIntegral |<< Token.natural lexer
 
-parseAdd ∷ Token.GenTokenParser String () Identity → Parser NatVal
+parseAdd :: Token.GenTokenParser String () Identity -> Parser NatVal
 parseAdd lexer = Token.reserved lexer "+" >> pure Add
 
-parseSub ∷ Token.GenTokenParser String () Identity → Parser NatVal
+parseSub :: Token.GenTokenParser String () Identity -> Parser NatVal
 parseSub lexer = Token.reserved lexer "-" >> pure Sub
 
-parseMul ∷ Token.GenTokenParser String () Identity → Parser NatVal
+parseMul :: Token.GenTokenParser String () Identity -> Parser NatVal
 parseMul lexer = Token.reserved lexer "*" >> pure Mul
 
-reservedNames ∷ [String]
+reservedNames :: [String]
 reservedNames = ["Nat", "+", "-", "*"]
 
-reservedOpNames ∷ [String]
+reservedOpNames :: [String]
 reservedOpNames = []
 
-naturals ∷ Parameterisation NatTy NatVal
-naturals = Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames
+nat :: Parameterisation NatTy NatVal
+nat =
+  Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames

--- a/src/Juvix/Core/Parameterisations/Naturals.hs
+++ b/src/Juvix/Core/Parameterisations/Naturals.hs
@@ -2,17 +2,22 @@
 
 module Juvix.Core.Parameterisations.Naturals where
 
-import           Juvix.Core.Types                    hiding (apply, parseTy,
-                                                      parseVal, reservedNames,
-                                                      reservedOpNames, typeOf)
-import           Juvix.Library                       hiding ((<|>))
-import           Prelude                             (String)
-import           Text.ParserCombinators.Parsec
+import Juvix.Core.Types hiding
+  ( apply,
+    parseTy,
+    parseVal,
+    reservedNames,
+    reservedOpNames,
+    typeOf,
+  )
+import Juvix.Library hiding ((<|>))
+import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
+import Prelude (String)
 
 -- k: primitive type: naturals
-data NatTy =
-  Nat
+data NatTy
+  = Nat
   deriving (Show, Eq)
 
 -- c: primitive constant and f: functions
@@ -24,49 +29,49 @@ data NatVal
   | Curried NatVal Natural
   deriving (Show, Eq)
 
-typeOf :: forall a. ([NatTy] -> a) -> NatVal -> Either a NatTy
-typeOf _ (Natural _)       = Right Nat
+typeOf ∷ ∀ a. ([NatTy] → a) → NatVal → Either a NatTy
+typeOf _ (Natural _) = Right Nat
 typeOf arrow (Curried _ _) = Left $ arrow [Nat, Nat]
-typeOf arrow Add           = Left $ arrow [Nat, Nat, Nat]
-typeOf arrow Sub           = Left $ arrow [Nat, Nat, Nat]
-typeOf arrow Mul           = Left $ arrow [Nat, Nat, Nat]
+typeOf arrow Add = Left $ arrow [Nat, Nat, Nat]
+typeOf arrow Sub = Left $ arrow [Nat, Nat, Nat]
+typeOf arrow Mul = Left $ arrow [Nat, Nat, Nat]
 
-apply :: NatVal -> NatVal -> Maybe NatVal
-apply Add (Natural x)             = pure (Curried Add x)
-apply Sub (Natural x)             = pure (Curried Sub x)
-apply Mul (Natural x)             = pure (Curried Mul x)
+apply ∷ NatVal → NatVal → Maybe NatVal
+apply Add (Natural x) = pure (Curried Add x)
+apply Sub (Natural x) = pure (Curried Sub x)
+apply Mul (Natural x) = pure (Curried Mul x)
 apply (Curried Add x) (Natural y) = pure (Natural (x + y))
 apply (Curried Sub x) (Natural y) = pure (Natural (x - y))
 apply (Curried Mul x) (Natural y) = pure (Natural (x * y))
-apply _ _                         = Nothing
+apply _ _ = Nothing
 
-parseTy :: Token.GenTokenParser String () Identity -> Parser NatTy
+parseTy ∷ Token.GenTokenParser String () Identity → Parser NatTy
 parseTy lexer = do
   Token.reserved lexer "Nat"
   pure Nat
 
-parseVal :: Token.GenTokenParser String () Identity -> Parser NatVal
+parseVal ∷ Token.GenTokenParser String () Identity → Parser NatVal
 parseVal lexer =
   parseNat lexer <|> parseAdd lexer <|> parseSub lexer <|> parseMul lexer
 
-parseNat :: Token.GenTokenParser String () Identity -> Parser NatVal
+parseNat ∷ Token.GenTokenParser String () Identity → Parser NatVal
 parseNat lexer = Natural . fromIntegral |<< Token.natural lexer
 
-parseAdd :: Token.GenTokenParser String () Identity -> Parser NatVal
+parseAdd ∷ Token.GenTokenParser String () Identity → Parser NatVal
 parseAdd lexer = Token.reserved lexer "+" >> pure Add
 
-parseSub :: Token.GenTokenParser String () Identity -> Parser NatVal
+parseSub ∷ Token.GenTokenParser String () Identity → Parser NatVal
 parseSub lexer = Token.reserved lexer "-" >> pure Sub
 
-parseMul :: Token.GenTokenParser String () Identity -> Parser NatVal
+parseMul ∷ Token.GenTokenParser String () Identity → Parser NatVal
 parseMul lexer = Token.reserved lexer "*" >> pure Mul
 
-reservedNames :: [String]
+reservedNames ∷ [String]
 reservedNames = ["Nat", "+", "-", "*"]
 
-reservedOpNames :: [String]
+reservedOpNames ∷ [String]
 reservedOpNames = []
 
-nat :: Parameterisation NatTy NatVal
+nat ∷ Parameterisation NatTy NatVal
 nat =
   Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames

--- a/src/Juvix/Core/Parameterisations/Naturals.hs
+++ b/src/Juvix/Core/Parameterisations/Naturals.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ExplicitForAll #-}
-
 module Juvix.Core.Parameterisations.Naturals where
 
 import Juvix.Core.Types hiding

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -2,46 +2,51 @@
 
 module Juvix.Core.Parameterisations.Unit where
 
-import           Juvix.Core.Types                    hiding (apply, parseTy,
-                                                      parseVal, reservedNames,
-                                                      reservedOpNames, typeOf)
-import           Juvix.Library                       hiding ((<|>))
-import           Prelude                             (String)
-import           Text.ParserCombinators.Parsec
+import Juvix.Core.Types hiding
+  ( apply,
+    parseTy,
+    parseVal,
+    reservedNames,
+    reservedOpNames,
+    typeOf,
+  )
+import Juvix.Library hiding ((<|>))
+import Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
+import Prelude (String)
 
 -- k: primitive type: unit
-data UnitTy =
-  TUnit
+data UnitTy
+  = TUnit
   deriving (Show, Eq)
 
 -- c: primitive constant and f: functions
-data UnitVal =
-  Unit
+data UnitVal
+  = Unit
   deriving (Show, Eq)
 
-typeOf :: forall a. ([UnitTy] -> a) -> UnitVal -> Either a UnitTy
+typeOf ∷ ∀ a. ([UnitTy] → a) → UnitVal → Either a UnitTy
 typeOf _ Unit = Right TUnit
 
-apply :: UnitVal -> UnitVal -> Maybe UnitVal
+apply ∷ UnitVal → UnitVal → Maybe UnitVal
 apply _ _ = Nothing
 
-parseTy :: Token.GenTokenParser String () Identity -> Parser UnitTy
+parseTy ∷ Token.GenTokenParser String () Identity → Parser UnitTy
 parseTy lexer = do
   Token.reserved lexer "TUnit"
   pure TUnit
 
-parseVal :: Token.GenTokenParser String () Identity -> Parser UnitVal
+parseVal ∷ Token.GenTokenParser String () Identity → Parser UnitVal
 parseVal lexer = do
   Token.reserved lexer "Unit"
   pure Unit
 
-reservedNames :: [String]
+reservedNames ∷ [String]
 reservedNames = ["TUnit", "Unit"]
 
-reservedOpNames :: [String]
+reservedOpNames ∷ [String]
 reservedOpNames = []
 
-unit :: Parameterisation UnitTy UnitVal
+unit ∷ Parameterisation UnitTy UnitVal
 unit =
   Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -1,0 +1,45 @@
+module Juvix.Core.Parameterisations.Unit where
+
+import Juvix.Core.Types hiding (apply, parseTy, parseVal, reservedNames, reservedOpNames, typeOf)
+import Juvix.Library hiding ((<|>))
+import Text.ParserCombinators.Parsec
+import qualified Text.ParserCombinators.Parsec.Token as Token
+import Prelude (String)
+
+-- k: primitive type: naturals
+data UnitTy
+  = TUnit
+  deriving (Show, Eq)
+
+-- c: primitive constant and f: functions
+data UnitVal
+  = Unit
+  deriving (Show, Eq)
+
+typeOf ∷ ∀ a. ([UnitTy] → a) → UnitVal → Either a UnitTy
+typeOf _ Unit = Right Unit
+
+apply ∷ UnitVal → UnitVal → Maybe UnitVal
+apply _ _ = Nothing
+
+parseTy ∷ Token.GenTokenParser String () Identity → Parser UnitTy
+parseTy lexer = do
+  Token.reserved lexer "TUnit"
+  pure TUnit
+
+parseVal ∷ Token.GenTokenParser String () Identity → Parser UnitVal
+parseVal lexer = do
+  Token.reserved lexer "Unit"
+  pure Unit
+
+parseUnit ∷ Token.GenTokenParser String () Identity → Parser UnitVal
+parseUnit lexer = Unitural . fromIntegral |<< Token.natural lexer
+
+reservedNames ∷ [String]
+reservedNames = ["TUnit", "Unit"]
+
+reservedOpNames ∷ [String]
+reservedOpNames = []
+
+unit ∷ Parameterisation UnitTy UnitVal
+unit = Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ExplicitForAll #-}
-
 module Juvix.Core.Parameterisations.Unit where
 
 import Juvix.Core.Types hiding

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -40,7 +40,7 @@ parseVal lexer = do
   pure Unit
 
 reservedNames ∷ [String]
-reservedNames = ["Unit","()"]
+reservedNames = ["Unit", "()"]
 
 reservedOpNames ∷ [String]
 reservedOpNames = []

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -31,16 +31,16 @@ apply _ _ = Nothing
 
 parseTy ∷ Token.GenTokenParser String () Identity → Parser UnitTy
 parseTy lexer = do
-  Token.reserved lexer "TUnit"
+  Token.reserved lexer "Unit"
   pure TUnit
 
 parseVal ∷ Token.GenTokenParser String () Identity → Parser UnitVal
 parseVal lexer = do
-  Token.reserved lexer "Unit"
+  Token.reserved lexer "()"
   pure Unit
 
 reservedNames ∷ [String]
-reservedNames = ["TUnit", "Unit"]
+reservedNames = ["Unit","()"]
 
 reservedOpNames ∷ [String]
 reservedOpNames = []

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -17,7 +17,7 @@ data UnitVal
   deriving (Show, Eq)
 
 typeOf ∷ ∀ a. ([UnitTy] → a) → UnitVal → Either a UnitTy
-typeOf _ Unit = Right Unit
+typeOf _ Unit = Right TUnit
 
 apply ∷ UnitVal → UnitVal → Maybe UnitVal
 apply _ _ = Nothing
@@ -31,9 +31,6 @@ parseVal ∷ Token.GenTokenParser String () Identity → Parser UnitVal
 parseVal lexer = do
   Token.reserved lexer "Unit"
   pure Unit
-
-parseUnit ∷ Token.GenTokenParser String () Identity → Parser UnitVal
-parseUnit lexer = Unitural . fromIntegral |<< Token.natural lexer
 
 reservedNames ∷ [String]
 reservedNames = ["TUnit", "Unit"]

--- a/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/src/Juvix/Core/Parameterisations/Unit.hs
@@ -1,42 +1,47 @@
+{-# LANGUAGE ExplicitForAll #-}
+
 module Juvix.Core.Parameterisations.Unit where
 
-import Juvix.Core.Types hiding (apply, parseTy, parseVal, reservedNames, reservedOpNames, typeOf)
-import Juvix.Library hiding ((<|>))
-import Text.ParserCombinators.Parsec
+import           Juvix.Core.Types                    hiding (apply, parseTy,
+                                                      parseVal, reservedNames,
+                                                      reservedOpNames, typeOf)
+import           Juvix.Library                       hiding ((<|>))
+import           Prelude                             (String)
+import           Text.ParserCombinators.Parsec
 import qualified Text.ParserCombinators.Parsec.Token as Token
-import Prelude (String)
 
--- k: primitive type: naturals
-data UnitTy
-  = TUnit
+-- k: primitive type: unit
+data UnitTy =
+  TUnit
   deriving (Show, Eq)
 
 -- c: primitive constant and f: functions
-data UnitVal
-  = Unit
+data UnitVal =
+  Unit
   deriving (Show, Eq)
 
-typeOf ∷ ∀ a. ([UnitTy] → a) → UnitVal → Either a UnitTy
+typeOf :: forall a. ([UnitTy] -> a) -> UnitVal -> Either a UnitTy
 typeOf _ Unit = Right TUnit
 
-apply ∷ UnitVal → UnitVal → Maybe UnitVal
+apply :: UnitVal -> UnitVal -> Maybe UnitVal
 apply _ _ = Nothing
 
-parseTy ∷ Token.GenTokenParser String () Identity → Parser UnitTy
+parseTy :: Token.GenTokenParser String () Identity -> Parser UnitTy
 parseTy lexer = do
   Token.reserved lexer "TUnit"
   pure TUnit
 
-parseVal ∷ Token.GenTokenParser String () Identity → Parser UnitVal
+parseVal :: Token.GenTokenParser String () Identity -> Parser UnitVal
 parseVal lexer = do
   Token.reserved lexer "Unit"
   pure Unit
 
-reservedNames ∷ [String]
+reservedNames :: [String]
 reservedNames = ["TUnit", "Unit"]
 
-reservedOpNames ∷ [String]
+reservedOpNames :: [String]
 reservedOpNames = []
 
-unit ∷ Parameterisation UnitTy UnitVal
-unit = Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames
+unit :: Parameterisation UnitTy UnitVal
+unit =
+  Parameterisation typeOf apply parseTy parseVal reservedNames reservedOpNames

--- a/test/CoreParser.hs
+++ b/test/CoreParser.hs
@@ -2,136 +2,140 @@
 
 module CoreParser where
 
-import           Juvix.Core.HR
-import           Juvix.Core.Parameterisations.Naturals
-import           Juvix.Core.Parameterisations.Unit
-import           Juvix.Core.Types
-import           Juvix.Core.Usage
-import           Juvix.Library
-import           Prelude                               (String)
-import qualified Test.Tasty                            as T
-import qualified Test.Tasty.HUnit                      as T
+import Juvix.Core.HR
+import Juvix.Core.Parameterisations.Naturals
+import Juvix.Core.Parameterisations.Unit
+import Juvix.Core.Types
+import Juvix.Core.Usage
+import Juvix.Library
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+import Prelude (String)
 
 -- | Term parser unit test generator. TODO: does it make sense for it to be NatTy?
-shouldParse :: String -> Term NatTy NatVal -> T.TestTree
+shouldParse ∷ String → Term NatTy NatVal → T.TestTree
 shouldParse str parsed =
   T.testCase (show str <> " should parse as " <> show parsed) $
-  Just parsed T.@=? parseString str
+    Just parsed T.@=? parseString str
 
-parseString :: String -> Maybe (Term NatTy NatVal)
+parseString ∷ String → Maybe (Term NatTy NatVal)
 parseString = generateParser nat
 
 -- | Primitive parser unit test generator.
-shouldParsePrim ::
-     forall primTy primVal. (Show primTy, Eq primTy, Show primVal, Eq primVal)
-  => Parameterisation primTy primVal
-  -> String
-  -> Term primTy primVal
-  -> T.TestTree
+shouldParsePrim ∷
+  ∀ primTy primVal.
+  (Show primTy, Eq primTy, Show primVal, Eq primVal) ⇒
+  Parameterisation primTy primVal →
+  String →
+  Term primTy primVal →
+  T.TestTree
 shouldParsePrim param str parsed =
   T.testCase (show str <> " should parse as " <> show parsed) $
-  Just parsed T.@=? parseStringPrim param str
+    Just parsed T.@=? parseStringPrim param str
 
-parseStringPrim ::
-     forall primTy primVal.
-     Parameterisation primTy primVal
-  -> String
-  -> Maybe (Term primTy primVal)
+parseStringPrim ∷
+  ∀ primTy primVal.
+  Parameterisation primTy primVal →
+  String →
+  Maybe (Term primTy primVal)
 parseStringPrim = generateParser
 
-test_star_n :: T.TestTree
+test_star_n ∷ T.TestTree
 test_star_n = shouldParse "* 0" (Star 0)
 
-test_star_n_parens :: T.TestTree
+test_star_n_parens ∷ T.TestTree
 test_star_n_parens = shouldParse "(* 1)" (Star 1)
 
-test_primitive_type_Nats :: T.TestTree
+test_primitive_type_Nats ∷ T.TestTree
 test_primitive_type_Nats = shouldParsePrim nat "Nat" (PrimTy Nat)
 
-test_primitive_type_unit :: T.TestTree
+test_primitive_type_unit ∷ T.TestTree
 test_primitive_type_unit = shouldParsePrim unit "TUnit" (PrimTy TUnit)
 
-test_primitive_val_unit :: T.TestTree
+test_primitive_val_unit ∷ T.TestTree
 test_primitive_val_unit = shouldParsePrim unit "Unit" (Elim (Prim Unit))
 
-test_dependent_fun :: T.TestTree
+test_dependent_fun ∷ T.TestTree
 test_dependent_fun = shouldParse "[Π] 1 * 0 * 0" (Pi (SNat 1) (Star 0) (Star 0))
 
-test_lam_identity :: T.TestTree
+test_lam_identity ∷ T.TestTree
 test_lam_identity = shouldParse "\\x -> x" (Lam "x" (Elim (Var "x")))
 
-test_lam_basic :: T.TestTree
+test_lam_basic ∷ T.TestTree
 test_lam_basic = shouldParse "\\x -> y" (Lam "x" (Elim (Var "y")))
 
-test_lam_nested :: T.TestTree
+test_lam_nested ∷ T.TestTree
 test_lam_nested =
   shouldParse "\\x -> \\y -> x" (Lam "x" (Lam "y" (Elim (Var "x"))))
 
-test_lam_nested_app :: T.TestTree
+test_lam_nested_app ∷ T.TestTree
 test_lam_nested_app =
   shouldParse
     "\\x -> \\y -> x y"
     (Lam "x" (Lam "y" (Elim (App (Var "x") (Elim (Var "y"))))))
 
-test_parse_nat_lit :: T.TestTree
+test_parse_nat_lit ∷ T.TestTree
 test_parse_nat_lit = shouldParse "3" (Elim (Prim (Natural 3)))
 
 -- TODO: Fix this; currently only applications of eliminations can be parsed.
 -- test_parse_app ∷ T.TestTree
 -- test_parse_app = shouldParse "(\\x -> x) y" (Elim (App (Lam "x" (Elim (Var "x"))) (Elim (Var "y"))))
-test_silent_convert_var :: T.TestTree
+test_silent_convert_var ∷ T.TestTree
 test_silent_convert_var = shouldParse "xyz" (Elim (Var "xyz"))
 
-test_silent_convert_app :: T.TestTree
+test_silent_convert_app ∷ T.TestTree
 test_silent_convert_app =
   shouldParse "fun var" (Elim (App (Var "fun") (Elim (Var "var"))))
 
-test_app_parens :: T.TestTree
+test_app_parens ∷ T.TestTree
 test_app_parens =
   shouldParse "(fun var)" (Elim (App (Var "fun") (Elim (Var "var"))))
 
-test_silent_convert_ann :: T.TestTree
+test_silent_convert_ann ∷ T.TestTree
 test_silent_convert_ann =
   shouldParse "@ (* 0) : w (* 0)" (Elim (Ann Omega (Star 0) (Star 0)))
 
-test_ann_func :: T.TestTree
+test_ann_func ∷ T.TestTree
 test_ann_func =
   shouldParse
     "@ (\\x -> x) : w (* 0)"
     (Elim (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)))
 
-test_ann_func_parens :: T.TestTree
+test_ann_func_parens ∷ T.TestTree
 test_ann_func_parens =
   shouldParse
     "(@ (\\x -> x) : w (* 0))"
     (Elim (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)))
 
-test_app_ann :: T.TestTree
+test_app_ann ∷ T.TestTree
 test_app_ann =
   shouldParse
     "(@ (\\x -> x) : w (* 0)) y"
     (Elim (App (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)) (Elim (Var "y"))))
 
-test_2_paren :: T.TestTree
+test_2_paren ∷ T.TestTree
 test_2_paren = shouldParse "(2)" (Elim (Prim (Natural 2)))
 
-test_parse_add :: T.TestTree
+test_parse_add ∷ T.TestTree
 test_parse_add =
   shouldParse
     "(+ 3 4)"
-    (Elim
-       (App (App (Prim Add) (Elim (Prim (Natural 3)))) (Elim (Prim (Natural 4)))))
+    ( Elim
+        (App (App (Prim Add) (Elim (Prim (Natural 3)))) (Elim (Prim (Natural 4))))
+    )
 
-test_parse_sub :: T.TestTree
+test_parse_sub ∷ T.TestTree
 test_parse_sub =
   shouldParse
     "(- 4 3)"
-    (Elim
-       (App (App (Prim Sub) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3)))))
+    ( Elim
+        (App (App (Prim Sub) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3))))
+    )
 
-test_parse_mul :: T.TestTree
+test_parse_mul ∷ T.TestTree
 test_parse_mul =
   shouldParse
     "(* 4 3)"
-    (Elim
-       (App (App (Prim Mul) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3)))))
+    ( Elim
+        (App (App (Prim Mul) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3))))
+    )

--- a/test/CoreParser.hs
+++ b/test/CoreParser.hs
@@ -1,14 +1,18 @@
+{-# LANGUAGE ExplicitForAll #-}
+
 module CoreParser where
 
 import Juvix.Core.HR
 import Juvix.Core.Parameterisations.Naturals
+import Juvix.Core.Parameterisations.Unit
+import Juvix.Core.Types
 import Juvix.Core.Usage
 import Juvix.Library
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
 import Prelude (String)
 
--- | Term parser unit test generator.
+-- | Term parser unit test generator. TODO: does it make sense for it to be NatTy?
 shouldParse ∷ String → Term NatTy NatVal → T.TestTree
 shouldParse str parsed =
   T.testCase (show str <> " should parse as " <> show parsed) $
@@ -17,6 +21,25 @@ shouldParse str parsed =
 parseString ∷ String → Maybe (Term NatTy NatVal)
 parseString = generateParser naturals
 
+-- | Primitive parser unit test generator.
+shouldParsePrim ∷
+  ∀ primTy primVal.
+  (Show primTy, Eq primTy, Show primVal, Eq primVal) ⇒
+  Parameterisation primTy primVal →
+  String →
+  Term primTy primVal →
+  T.TestTree
+shouldParsePrim param str parsed =
+  T.testCase (show str <> " should parse as " <> show parsed) $
+    Just parsed T.@=? parseStringPrim param str
+
+parseStringPrim ∷
+  ∀ primTy primVal.
+  Parameterisation primTy primVal →
+  String →
+  Maybe (Term primTy primVal)
+parseStringPrim param = generateParser param
+
 test_star_n ∷ T.TestTree
 test_star_n = shouldParse "* 0" (Star 0)
 
@@ -24,13 +47,16 @@ test_star_n_parens ∷ T.TestTree
 test_star_n_parens = shouldParse "(* 1)" (Star 1)
 
 test_primitive_type_Nats ∷ T.TestTree
-test_primitive_type_Nats = shouldParse "Nat" (PrimTy Nat)
+test_primitive_type_Nats = shouldParsePrim naturals "Nat" (PrimTy Nat)
+
+test_primitive_type_unit ∷ T.TestTree
+test_primitive_type_unit = shouldParsePrim unit "TUnit" (PrimTy TUnit)
+
+test_primitive_val_unit ∷ T.TestTree
+test_primitive_val_unit = shouldParsePrim unit "Unit" (Elim (Prim Unit))
 
 test_dependent_fun ∷ T.TestTree
-test_dependent_fun =
-  shouldParse
-    "[Π] 1 * 0 * 0"
-    (Pi (SNat 1) (Star 0) (Star 0))
+test_dependent_fun = shouldParse "[Π] 1 * 0 * 0" (Pi (SNat 1) (Star 0) (Star 0))
 
 test_lam_identity ∷ T.TestTree
 test_lam_identity = shouldParse "\\x -> x" (Lam "x" (Elim (Var "x")))
@@ -39,10 +65,14 @@ test_lam_basic ∷ T.TestTree
 test_lam_basic = shouldParse "\\x -> y" (Lam "x" (Elim (Var "y")))
 
 test_lam_nested ∷ T.TestTree
-test_lam_nested = shouldParse "\\x -> \\y -> x" (Lam "x" (Lam "y" (Elim (Var "x"))))
+test_lam_nested =
+  shouldParse "\\x -> \\y -> x" (Lam "x" (Lam "y" (Elim (Var "x"))))
 
 test_lam_nested_app ∷ T.TestTree
-test_lam_nested_app = shouldParse "\\x -> \\y -> x y" (Lam "x" (Lam "y" (Elim (App (Var "x") (Elim (Var "y"))))))
+test_lam_nested_app =
+  shouldParse
+    "\\x -> \\y -> x y"
+    (Lam "x" (Lam "y" (Elim (App (Var "x") (Elim (Var "y"))))))
 
 test_parse_nat_lit ∷ T.TestTree
 test_parse_nat_lit = shouldParse "3" (Elim (Prim (Natural 3)))
@@ -50,36 +80,62 @@ test_parse_nat_lit = shouldParse "3" (Elim (Prim (Natural 3)))
 -- TODO: Fix this; currently only applications of eliminations can be parsed.
 -- test_parse_app ∷ T.TestTree
 -- test_parse_app = shouldParse "(\\x -> x) y" (Elim (App (Lam "x" (Elim (Var "x"))) (Elim (Var "y"))))
-
 test_silent_convert_var ∷ T.TestTree
 test_silent_convert_var = shouldParse "xyz" (Elim (Var "xyz"))
 
 test_silent_convert_app ∷ T.TestTree
-test_silent_convert_app = shouldParse "fun var" (Elim (App (Var "fun") (Elim (Var "var"))))
+test_silent_convert_app =
+  shouldParse "fun var" (Elim (App (Var "fun") (Elim (Var "var"))))
 
 test_app_parens ∷ T.TestTree
-test_app_parens = shouldParse "(fun var)" (Elim (App (Var "fun") (Elim (Var "var"))))
+test_app_parens =
+  shouldParse "(fun var)" (Elim (App (Var "fun") (Elim (Var "var"))))
 
 test_silent_convert_ann ∷ T.TestTree
-test_silent_convert_ann = shouldParse "@ (* 0) : w (* 0)" (Elim (Ann Omega (Star 0) (Star 0)))
+test_silent_convert_ann =
+  shouldParse "@ (* 0) : w (* 0)" (Elim (Ann Omega (Star 0) (Star 0)))
 
 test_ann_func ∷ T.TestTree
-test_ann_func = shouldParse "@ (\\x -> x) : w (* 0)" (Elim (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)))
+test_ann_func =
+  shouldParse
+    "@ (\\x -> x) : w (* 0)"
+    (Elim (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)))
 
 test_ann_func_parens ∷ T.TestTree
-test_ann_func_parens = shouldParse "(@ (\\x -> x) : w (* 0))" (Elim (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)))
+test_ann_func_parens =
+  shouldParse
+    "(@ (\\x -> x) : w (* 0))"
+    (Elim (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)))
 
 test_app_ann ∷ T.TestTree
-test_app_ann = shouldParse "(@ (\\x -> x) : w (* 0)) y" (Elim (App (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)) (Elim (Var "y"))))
+test_app_ann =
+  shouldParse
+    "(@ (\\x -> x) : w (* 0)) y"
+    (Elim (App (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)) (Elim (Var "y"))))
 
 test_2_paren ∷ T.TestTree
 test_2_paren = shouldParse "(2)" (Elim (Prim (Natural 2)))
 
 test_parse_add ∷ T.TestTree
-test_parse_add = shouldParse "(+ 3 4)" (Elim (App (App (Prim Add) (Elim (Prim (Natural 3)))) (Elim (Prim (Natural 4)))))
+test_parse_add =
+  shouldParse
+    "(+ 3 4)"
+    ( Elim
+        (App (App (Prim Add) (Elim (Prim (Natural 3)))) (Elim (Prim (Natural 4))))
+    )
 
 test_parse_sub ∷ T.TestTree
-test_parse_sub = shouldParse "(- 4 3)" (Elim (App (App (Prim Sub) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3)))))
+test_parse_sub =
+  shouldParse
+    "(- 4 3)"
+    ( Elim
+        (App (App (Prim Sub) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3))))
+    )
 
 test_parse_mul ∷ T.TestTree
-test_parse_mul = shouldParse "(* 4 3)" (Elim (App (App (Prim Mul) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3)))))
+test_parse_mul =
+  shouldParse
+    "(* 4 3)"
+    ( Elim
+        (App (App (Prim Mul) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3))))
+    )

--- a/test/CoreParser.hs
+++ b/test/CoreParser.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ExplicitForAll #-}
-
 module CoreParser where
 
 import Juvix.Core.HR

--- a/test/CoreParser.hs
+++ b/test/CoreParser.hs
@@ -48,10 +48,10 @@ test_primitive_type_Nats ∷ T.TestTree
 test_primitive_type_Nats = shouldParsePrim nat "Nat" (PrimTy Nat)
 
 test_primitive_type_unit ∷ T.TestTree
-test_primitive_type_unit = shouldParsePrim unit "TUnit" (PrimTy TUnit)
+test_primitive_type_unit = shouldParsePrim unit "Unit" (PrimTy TUnit)
 
 test_primitive_val_unit ∷ T.TestTree
-test_primitive_val_unit = shouldParsePrim unit "Unit" (Elim (Prim Unit))
+test_primitive_val_unit = shouldParsePrim unit "()" (Elim (Prim Unit))
 
 test_dependent_fun ∷ T.TestTree
 test_dependent_fun = shouldParse "[Π] 1 * 0 * 0" (Pi (SNat 1) (Star 0) (Star 0))

--- a/test/CoreParser.hs
+++ b/test/CoreParser.hs
@@ -2,140 +2,136 @@
 
 module CoreParser where
 
-import Juvix.Core.HR
-import Juvix.Core.Parameterisations.Naturals
-import Juvix.Core.Parameterisations.Unit
-import Juvix.Core.Types
-import Juvix.Core.Usage
-import Juvix.Library
-import qualified Test.Tasty as T
-import qualified Test.Tasty.HUnit as T
-import Prelude (String)
+import           Juvix.Core.HR
+import           Juvix.Core.Parameterisations.Naturals
+import           Juvix.Core.Parameterisations.Unit
+import           Juvix.Core.Types
+import           Juvix.Core.Usage
+import           Juvix.Library
+import           Prelude                               (String)
+import qualified Test.Tasty                            as T
+import qualified Test.Tasty.HUnit                      as T
 
 -- | Term parser unit test generator. TODO: does it make sense for it to be NatTy?
-shouldParse ∷ String → Term NatTy NatVal → T.TestTree
+shouldParse :: String -> Term NatTy NatVal -> T.TestTree
 shouldParse str parsed =
   T.testCase (show str <> " should parse as " <> show parsed) $
-    Just parsed T.@=? parseString str
+  Just parsed T.@=? parseString str
 
-parseString ∷ String → Maybe (Term NatTy NatVal)
-parseString = generateParser naturals
+parseString :: String -> Maybe (Term NatTy NatVal)
+parseString = generateParser nat
 
 -- | Primitive parser unit test generator.
-shouldParsePrim ∷
-  ∀ primTy primVal.
-  (Show primTy, Eq primTy, Show primVal, Eq primVal) ⇒
-  Parameterisation primTy primVal →
-  String →
-  Term primTy primVal →
-  T.TestTree
+shouldParsePrim ::
+     forall primTy primVal. (Show primTy, Eq primTy, Show primVal, Eq primVal)
+  => Parameterisation primTy primVal
+  -> String
+  -> Term primTy primVal
+  -> T.TestTree
 shouldParsePrim param str parsed =
   T.testCase (show str <> " should parse as " <> show parsed) $
-    Just parsed T.@=? parseStringPrim param str
+  Just parsed T.@=? parseStringPrim param str
 
-parseStringPrim ∷
-  ∀ primTy primVal.
-  Parameterisation primTy primVal →
-  String →
-  Maybe (Term primTy primVal)
-parseStringPrim param = generateParser param
+parseStringPrim ::
+     forall primTy primVal.
+     Parameterisation primTy primVal
+  -> String
+  -> Maybe (Term primTy primVal)
+parseStringPrim = generateParser
 
-test_star_n ∷ T.TestTree
+test_star_n :: T.TestTree
 test_star_n = shouldParse "* 0" (Star 0)
 
-test_star_n_parens ∷ T.TestTree
+test_star_n_parens :: T.TestTree
 test_star_n_parens = shouldParse "(* 1)" (Star 1)
 
-test_primitive_type_Nats ∷ T.TestTree
-test_primitive_type_Nats = shouldParsePrim naturals "Nat" (PrimTy Nat)
+test_primitive_type_Nats :: T.TestTree
+test_primitive_type_Nats = shouldParsePrim nat "Nat" (PrimTy Nat)
 
-test_primitive_type_unit ∷ T.TestTree
+test_primitive_type_unit :: T.TestTree
 test_primitive_type_unit = shouldParsePrim unit "TUnit" (PrimTy TUnit)
 
-test_primitive_val_unit ∷ T.TestTree
+test_primitive_val_unit :: T.TestTree
 test_primitive_val_unit = shouldParsePrim unit "Unit" (Elim (Prim Unit))
 
-test_dependent_fun ∷ T.TestTree
+test_dependent_fun :: T.TestTree
 test_dependent_fun = shouldParse "[Π] 1 * 0 * 0" (Pi (SNat 1) (Star 0) (Star 0))
 
-test_lam_identity ∷ T.TestTree
+test_lam_identity :: T.TestTree
 test_lam_identity = shouldParse "\\x -> x" (Lam "x" (Elim (Var "x")))
 
-test_lam_basic ∷ T.TestTree
+test_lam_basic :: T.TestTree
 test_lam_basic = shouldParse "\\x -> y" (Lam "x" (Elim (Var "y")))
 
-test_lam_nested ∷ T.TestTree
+test_lam_nested :: T.TestTree
 test_lam_nested =
   shouldParse "\\x -> \\y -> x" (Lam "x" (Lam "y" (Elim (Var "x"))))
 
-test_lam_nested_app ∷ T.TestTree
+test_lam_nested_app :: T.TestTree
 test_lam_nested_app =
   shouldParse
     "\\x -> \\y -> x y"
     (Lam "x" (Lam "y" (Elim (App (Var "x") (Elim (Var "y"))))))
 
-test_parse_nat_lit ∷ T.TestTree
+test_parse_nat_lit :: T.TestTree
 test_parse_nat_lit = shouldParse "3" (Elim (Prim (Natural 3)))
 
 -- TODO: Fix this; currently only applications of eliminations can be parsed.
 -- test_parse_app ∷ T.TestTree
 -- test_parse_app = shouldParse "(\\x -> x) y" (Elim (App (Lam "x" (Elim (Var "x"))) (Elim (Var "y"))))
-test_silent_convert_var ∷ T.TestTree
+test_silent_convert_var :: T.TestTree
 test_silent_convert_var = shouldParse "xyz" (Elim (Var "xyz"))
 
-test_silent_convert_app ∷ T.TestTree
+test_silent_convert_app :: T.TestTree
 test_silent_convert_app =
   shouldParse "fun var" (Elim (App (Var "fun") (Elim (Var "var"))))
 
-test_app_parens ∷ T.TestTree
+test_app_parens :: T.TestTree
 test_app_parens =
   shouldParse "(fun var)" (Elim (App (Var "fun") (Elim (Var "var"))))
 
-test_silent_convert_ann ∷ T.TestTree
+test_silent_convert_ann :: T.TestTree
 test_silent_convert_ann =
   shouldParse "@ (* 0) : w (* 0)" (Elim (Ann Omega (Star 0) (Star 0)))
 
-test_ann_func ∷ T.TestTree
+test_ann_func :: T.TestTree
 test_ann_func =
   shouldParse
     "@ (\\x -> x) : w (* 0)"
     (Elim (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)))
 
-test_ann_func_parens ∷ T.TestTree
+test_ann_func_parens :: T.TestTree
 test_ann_func_parens =
   shouldParse
     "(@ (\\x -> x) : w (* 0))"
     (Elim (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)))
 
-test_app_ann ∷ T.TestTree
+test_app_ann :: T.TestTree
 test_app_ann =
   shouldParse
     "(@ (\\x -> x) : w (* 0)) y"
     (Elim (App (Ann Omega (Lam "x" (Elim (Var "x"))) (Star 0)) (Elim (Var "y"))))
 
-test_2_paren ∷ T.TestTree
+test_2_paren :: T.TestTree
 test_2_paren = shouldParse "(2)" (Elim (Prim (Natural 2)))
 
-test_parse_add ∷ T.TestTree
+test_parse_add :: T.TestTree
 test_parse_add =
   shouldParse
     "(+ 3 4)"
-    ( Elim
-        (App (App (Prim Add) (Elim (Prim (Natural 3)))) (Elim (Prim (Natural 4))))
-    )
+    (Elim
+       (App (App (Prim Add) (Elim (Prim (Natural 3)))) (Elim (Prim (Natural 4)))))
 
-test_parse_sub ∷ T.TestTree
+test_parse_sub :: T.TestTree
 test_parse_sub =
   shouldParse
     "(- 4 3)"
-    ( Elim
-        (App (App (Prim Sub) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3))))
-    )
+    (Elim
+       (App (App (Prim Sub) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3)))))
 
-test_parse_mul ∷ T.TestTree
+test_parse_mul :: T.TestTree
 test_parse_mul =
   shouldParse
     "(* 4 3)"
-    ( Elim
-        (App (App (Prim Mul) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3))))
-    )
+    (Elim
+       (App (App (Prim Mul) (Elim (Prim (Natural 4)))) (Elim (Prim (Natural 3)))))

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -17,18 +17,18 @@ type Value = IR.Value primTy primVal
 
 type Annotation = IR.Annotation primTy primVal
  -}
-identity ∷ IR.Term
+identity ∷ IR.Term NatTy NatVal
 identity = IR.Lam (IR.Elim (IR.Bound 0))
 
-identityCompTy ∷ IR.Annotation
+identityCompTy ∷ IR.Annotation NatTy NatVal
 identityCompTy =
   (SNat 1, IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
 
-identityContTy ∷ IR.Annotation
+identityContTy ∷ IR.Annotation NatTy NatVal
 identityContTy =
   (SNat 0, IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
 
-identityApplication ∷ IR.Term
+identityApplication ∷ IR.Term NatTy NatVal
 identityApplication =
   IR.Elim
     ( IR.App
@@ -40,7 +40,7 @@ identityApplication =
         (IR.Elim (IR.Prim (Natural 1)))
     )
 
-natTy ∷ IR.Annotation
+natTy ∷ IR.Annotation NatTy NatVal
 natTy = (SNat 1, IR.VPrimTy Nat)
 
 test_identity_computational ∷ T.TestTree
@@ -109,7 +109,7 @@ shouldEval term res =
 one ∷ IR.Term
 one = IR.Lam $ IR.Lam $ IR.Elim $ IR.App (IR.Bound 1) (IR.Elim (IR.Bound 0))
 
-oneCompTy ∷ IR.Annotation
+oneCompTy ∷ IR.Annotation NatTy NatVal
 oneCompTy =
   ( SNat 1,
     IR.VPi
@@ -125,7 +125,7 @@ two =
     $ IR.Elim
     $ IR.App (IR.Bound 1) (IR.Elim (IR.App (IR.Bound 1) (IR.Elim (IR.Bound 0))))
 
-twoCompTy ∷ IR.Annotation
+twoCompTy ∷ IR.Annotation NatTy NatVal
 twoCompTy =
   ( SNat 1,
     IR.VPi

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -3,14 +3,14 @@
 -- | Tests for the type checker and evaluator in Core/IR/Typechecker.hs
 module CoreTypechecker where
 
-import qualified Juvix.Core.IR                         as IR
-import           Juvix.Core.Parameterisations.Naturals
-import           Juvix.Core.Parameterisations.Unit
-import           Juvix.Core.Types
-import           Juvix.Core.Usage
-import           Juvix.Library                         hiding (identity)
-import qualified Test.Tasty                            as T
-import qualified Test.Tasty.HUnit                      as T
+import qualified Juvix.Core.IR as IR
+import Juvix.Core.Parameterisations.Naturals
+import Juvix.Core.Parameterisations.Unit
+import Juvix.Core.Types
+import Juvix.Core.Usage
+import Juvix.Library hiding (identity)
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
 
 type NatTerm = IR.Term NatTy NatVal
 
@@ -28,138 +28,150 @@ type UnitValue = IR.Value UnitTy UnitVal
 
 type UnitAnnotation = IR.Annotation UnitTy UnitVal
 
-identity :: forall primTy primVal. IR.Term primTy primVal
+identity ∷ ∀ primTy primVal. IR.Term primTy primVal
 identity = IR.Lam (IR.Elim (IR.Bound 0))
 
-identityNatCompTy :: NatAnnotation
+identityNatCompTy ∷ NatAnnotation
 identityNatCompTy =
   (SNat 1, IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
 
-identityUnitCompTy :: UnitAnnotation
+identityUnitCompTy ∷ UnitAnnotation
 identityUnitCompTy =
   (SNat 1, IR.VPi (SNat 1) (IR.VPrimTy TUnit) (const (IR.VPrimTy TUnit)))
 
-identityNatContTy :: NatAnnotation
+identityNatContTy ∷ NatAnnotation
 identityNatContTy =
   (SNat 0, IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
 
-identityApplication :: NatTerm
+identityApplication ∷ NatTerm
 identityApplication =
   IR.Elim
-    (IR.App
-       (IR.Ann
-          (SNat 1)
-          identity
-          (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat)))
-       (IR.Elim (IR.Prim (Natural 1))))
+    ( IR.App
+        ( IR.Ann
+            (SNat 1)
+            identity
+            (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat))
+        )
+        (IR.Elim (IR.Prim (Natural 1)))
+    )
 
-natTy :: NatAnnotation
+natTy ∷ NatAnnotation
 natTy = (SNat 1, IR.VPrimTy Nat)
 
-test_identity_computational :: T.TestTree
+test_identity_computational ∷ T.TestTree
 test_identity_computational = shouldCheck nat identity identityNatCompTy
 
-test_identity_unit_computational :: T.TestTree
+test_identity_unit_computational ∷ T.TestTree
 test_identity_unit_computational = shouldCheck unit identity identityUnitCompTy
 
-test_identity_contemplation :: T.TestTree
+test_identity_contemplation ∷ T.TestTree
 test_identity_contemplation = shouldCheck nat identity identityNatContTy
 
-test_identity_application :: T.TestTree
+test_identity_application ∷ T.TestTree
 test_identity_application = shouldCheck nat identityApplication natTy
 
-test_nats_type_star0 :: T.TestTree
+test_nats_type_star0 ∷ T.TestTree
 test_nats_type_star0 = shouldCheck nat (IR.PrimTy Nat) (SNat 0, IR.VStar 0)
 
-test_nat1 :: T.TestTree
+test_nat1 ∷ T.TestTree
 test_nat1 = shouldInfer nat (IR.Prim (Natural 1)) (Omega, IR.VPrimTy Nat)
 
-test_add_nat :: T.TestTree
+test_add_nat ∷ T.TestTree
 test_add_nat =
   shouldInfer
     nat
-    (IR.App
-       (IR.App (IR.Prim Add) (IR.Elim (IR.Prim (Natural 1))))
-       (IR.Elim (IR.Prim (Natural 2))))
+    ( IR.App
+        (IR.App (IR.Prim Add) (IR.Elim (IR.Prim (Natural 1))))
+        (IR.Elim (IR.Prim (Natural 2)))
+    )
     (Omega, IR.VPrimTy Nat)
 
-test_eval_add :: T.TestTree
+test_eval_add ∷ T.TestTree
 test_eval_add =
   shouldEval
     nat
-    (IR.Elim
-       (IR.App
-          (IR.App (IR.Prim Add) (IR.Elim (IR.Prim (Natural 1))))
-          (IR.Elim (IR.Prim (Natural 2)))))
+    ( IR.Elim
+        ( IR.App
+            (IR.App (IR.Prim Add) (IR.Elim (IR.Prim (Natural 1))))
+            (IR.Elim (IR.Prim (Natural 2)))
+        )
+    )
     (IR.VPrim (Natural 3))
 
-test_eval_sub :: T.TestTree
+test_eval_sub ∷ T.TestTree
 test_eval_sub =
   shouldEval
     nat
-    (IR.Elim
-       (IR.App
-          (IR.App (IR.Prim Sub) (IR.Elim (IR.Prim (Natural 5))))
-          (IR.Elim (IR.Prim (Natural 2)))))
+    ( IR.Elim
+        ( IR.App
+            (IR.App (IR.Prim Sub) (IR.Elim (IR.Prim (Natural 5))))
+            (IR.Elim (IR.Prim (Natural 2)))
+        )
+    )
     (IR.VPrim (Natural 3))
 
 --unit tests for cType
-shouldCheck ::
-     forall primTy primVal. (Show primTy, Eq primTy, Show primVal, Eq primVal)
-  => Parameterisation primTy primVal
-  -> IR.Term primTy primVal
-  -> IR.Annotation primTy primVal
-  -> T.TestTree
+shouldCheck ∷
+  ∀ primTy primVal.
+  (Show primTy, Eq primTy, Show primVal, Eq primVal) ⇒
+  Parameterisation primTy primVal →
+  IR.Term primTy primVal →
+  IR.Annotation primTy primVal →
+  T.TestTree
 shouldCheck param term ann =
   T.testCase (show term <> " should check as type " <> show ann) $
-  IR.cType param 0 [] term ann T.@=? Right ()
+    IR.cType param 0 [] term ann T.@=? Right ()
 
 --unit tests for iType
-shouldInfer ::
-     forall primTy primVal. (Show primTy, Eq primTy, Show primVal, Eq primVal)
-  => Parameterisation primTy primVal
-  -> IR.Elim primTy primVal
-  -> IR.Annotation primTy primVal
-  -> T.TestTree
+shouldInfer ∷
+  ∀ primTy primVal.
+  (Show primTy, Eq primTy, Show primVal, Eq primVal) ⇒
+  Parameterisation primTy primVal →
+  IR.Elim primTy primVal →
+  IR.Annotation primTy primVal →
+  T.TestTree
 shouldInfer param term ann =
   T.testCase (show term <> " should infer to type " <> show ann) $
-  IR.iType0 param [] term T.@=? Right ann
+    IR.iType0 param [] term T.@=? Right ann
 
-shouldEval ::
-     forall primTy primVal. (Show primTy, Eq primTy, Show primVal, Eq primVal)
-  => Parameterisation primTy primVal
-  -> IR.Term primTy primVal
-  -> IR.Value primTy primVal
-  -> T.TestTree
+shouldEval ∷
+  ∀ primTy primVal.
+  (Show primTy, Eq primTy, Show primVal, Eq primVal) ⇒
+  Parameterisation primTy primVal →
+  IR.Term primTy primVal →
+  IR.Value primTy primVal →
+  T.TestTree
 shouldEval param term res =
   T.testCase (show term <> " should evaluate to " <> show res) $
-  IR.cEval param term IR.initEnv T.@=? res
+    IR.cEval param term IR.initEnv T.@=? res
 
-one :: forall primTy primVal. IR.Term primTy primVal
+one ∷ ∀ primTy primVal. IR.Term primTy primVal
 one = IR.Lam $ IR.Lam $ IR.Elim $ IR.App (IR.Bound 1) (IR.Elim (IR.Bound 0))
 
-oneCompTy :: NatAnnotation
+oneCompTy ∷ NatAnnotation
 oneCompTy =
-  ( SNat 1
-  , IR.VPi
+  ( SNat 1,
+    IR.VPi
       (SNat 1)
       (IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
-      (const (IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))))
+      (const (IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
+  )
 
-two :: forall primTy primVal. IR.Term primTy primVal
+two ∷ ∀ primTy primVal. IR.Term primTy primVal
 two =
-  IR.Lam $
-  IR.Lam $
-  IR.Elim $
-  IR.App (IR.Bound 1) (IR.Elim (IR.App (IR.Bound 1) (IR.Elim (IR.Bound 0))))
+  IR.Lam
+    $ IR.Lam
+    $ IR.Elim
+    $ IR.App (IR.Bound 1) (IR.Elim (IR.App (IR.Bound 1) (IR.Elim (IR.Bound 0))))
 
-twoCompTy :: NatAnnotation
+twoCompTy ∷ NatAnnotation
 twoCompTy =
-  ( SNat 1
-  , IR.VPi
+  ( SNat 1,
+    IR.VPi
       (SNat 2)
       (IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
-      (const (IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))))
+      (const (IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
+  )
 -- property tests of type checker:
 -- the term's inferred type equals to the input type
 -- property test of evaluator:

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -3,38 +3,44 @@ module CoreTypechecker where
 
 import qualified Juvix.Core.IR as IR
 import Juvix.Core.Parameterisations.Naturals
+import Juvix.Core.Parameterisations.Unit
 import Juvix.Core.Usage
 import Juvix.Library hiding (identity)
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
 
-type Term = IR.Term NatTy NatVal
+{- type Term = IR.Term primTy primVal
 
-type Elim = IR.Elim NatTy NatVal
+type Elim = IR.Elim primTy primVal
 
-type Value = IR.Value NatTy NatVal
+type Value = IR.Value primTy primVal
 
-type Annotation = IR.Annotation NatTy NatVal
-
-identity ∷ Term
+type Annotation = IR.Annotation primTy primVal
+ -}
+identity ∷ IR.Term
 identity = IR.Lam (IR.Elim (IR.Bound 0))
 
-identityCompTy ∷ Annotation
+identityCompTy ∷ IR.Annotation
 identityCompTy =
-  ( SNat 1,
-    IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))
-  )
+  (SNat 1, IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
 
-identityContTy ∷ Annotation
+identityContTy ∷ IR.Annotation
 identityContTy =
-  ( SNat 0,
-    IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))
-  )
+  (SNat 0, IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
 
-identityApplication ∷ Term
-identityApplication = IR.Elim (IR.App (IR.Ann (SNat 1) identity (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat))) (IR.Elim (IR.Prim (Natural 1))))
+identityApplication ∷ IR.Term
+identityApplication =
+  IR.Elim
+    ( IR.App
+        ( IR.Ann
+            (SNat 1)
+            identity
+            (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat))
+        )
+        (IR.Elim (IR.Prim (Natural 1)))
+    )
 
-natTy ∷ Annotation
+natTy ∷ IR.Annotation
 natTy = (SNat 1, IR.VPrimTy Nat)
 
 test_identity_computational ∷ T.TestTree
@@ -53,90 +59,79 @@ test_nat1 ∷ T.TestTree
 test_nat1 = shouldInfer (IR.Prim (Natural 1)) (Omega, IR.VPrimTy Nat)
 
 test_add_nat ∷ T.TestTree
-test_add_nat = shouldInfer (IR.App (IR.App (IR.Prim Add) (IR.Elim (IR.Prim (Natural 1)))) (IR.Elim (IR.Prim (Natural 2)))) (Omega, IR.VPrimTy Nat)
+test_add_nat =
+  shouldInfer
+    ( IR.App
+        (IR.App (IR.Prim Add) (IR.Elim (IR.Prim (Natural 1))))
+        (IR.Elim (IR.Prim (Natural 2)))
+    )
+    (Omega, IR.VPrimTy Nat)
 
 test_eval_add ∷ T.TestTree
-test_eval_add = shouldEval (IR.Elim (IR.App (IR.App (IR.Prim Add) (IR.Elim (IR.Prim (Natural 1)))) (IR.Elim (IR.Prim (Natural 2))))) (IR.VPrim (Natural 3))
+test_eval_add =
+  shouldEval
+    ( IR.Elim
+        ( IR.App
+            (IR.App (IR.Prim Add) (IR.Elim (IR.Prim (Natural 1))))
+            (IR.Elim (IR.Prim (Natural 2)))
+        )
+    )
+    (IR.VPrim (Natural 3))
 
 test_eval_sub ∷ T.TestTree
-test_eval_sub = shouldEval (IR.Elim (IR.App (IR.App (IR.Prim Sub) (IR.Elim (IR.Prim (Natural 5)))) (IR.Elim (IR.Prim (Natural 2))))) (IR.VPrim (Natural 3))
+test_eval_sub =
+  shouldEval
+    ( IR.Elim
+        ( IR.App
+            (IR.App (IR.Prim Sub) (IR.Elim (IR.Prim (Natural 5))))
+            (IR.Elim (IR.Prim (Natural 2)))
+        )
+    )
+    (IR.VPrim (Natural 3))
 
 --unit tests for cType
-shouldCheck ∷ Term → Annotation → T.TestTree
+shouldCheck ∷ IR.Term → IR.Annotation → T.TestTree
 shouldCheck term ann =
   T.testCase (show term <> " should check as type " <> show ann) $
     IR.cType naturals 0 [] term ann T.@=? Right ()
 
 --unit tests for iType
-shouldInfer ∷ Elim → Annotation → T.TestTree
+shouldInfer ∷ IR.Elim → IR.Annotation → T.TestTree
 shouldInfer term ann =
   T.testCase (show term <> " should infer to type " <> show ann) $
     IR.iType0 naturals [] term T.@=? Right ann
 
-shouldEval ∷ Term → Value → T.TestTree
+shouldEval ∷ IR.Term → IR.Value → T.TestTree
 shouldEval term res =
   T.testCase (show term <> " should evaluate to " <> show res) $
     IR.cEval naturals term IR.initEnv T.@=? res
 
-one ∷ Term
-one =
-  IR.Lam
-    $ IR.Lam
-    $ IR.Elim
-    $ IR.App
-      (IR.Bound 1)
-      (IR.Elim (IR.Bound 0))
+one ∷ IR.Term
+one = IR.Lam $ IR.Lam $ IR.Elim $ IR.App (IR.Bound 1) (IR.Elim (IR.Bound 0))
 
-oneCompTy ∷ Annotation
+oneCompTy ∷ IR.Annotation
 oneCompTy =
   ( SNat 1,
     IR.VPi
       (SNat 1)
-      ( IR.VPi
-          (SNat 1)
-          (IR.VPrimTy Nat)
-          (const (IR.VPrimTy Nat))
-      )
-      ( const
-          ( IR.VPi
-              (SNat 1)
-              (IR.VPrimTy Nat)
-              (const (IR.VPrimTy Nat))
-          )
-      )
+      (IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
+      (const (IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
   )
 
-two ∷ Term
+two ∷ IR.Term
 two =
   IR.Lam
     $ IR.Lam
     $ IR.Elim
-    $ IR.App
-      (IR.Bound 1)
-      ( IR.Elim
-          ( IR.App
-              (IR.Bound 1)
-              (IR.Elim (IR.Bound 0))
-          )
-      )
+    $ IR.App (IR.Bound 1) (IR.Elim (IR.App (IR.Bound 1) (IR.Elim (IR.Bound 0))))
 
-twoCompTy ∷ Annotation
+twoCompTy ∷ IR.Annotation
 twoCompTy =
   ( SNat 1,
     IR.VPi
       (SNat 2)
-      ( IR.VPi
-          (SNat 1)
-          (IR.VPrimTy Nat)
-          (const (IR.VPrimTy Nat))
-      )
-      ( const
-          ( IR.VPi
-              (SNat 1)
-              (IR.VPrimTy Nat)
-              (const (IR.VPrimTy Nat))
-          )
-      )
+      (IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
+      (const (IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
   )
 -- property tests of type checker:
 -- the term's inferred type equals to the input type
@@ -149,7 +144,6 @@ lamProp cterm env = IR.App (cEval (IR.Lam IR.Bound 0) env) cterm == cterm-}
 -- constProp (Star i) env = cEval (Star i) env == IR.VStar i
 -- constProp IR.PrimTy Nat env     = cEval IR.PrimTy Nat env == IR.VPrimTy Nat
 -- constProp _ _          = True --Not testing non-const terms
-
 {- TODO need to combine generators to generate
    Terms http://hackage.haskell.org/package/QuickCheck-2.13.2/docs/Test-QuickCheck-Gen.html
 instance Arbitrary Term where

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ExplicitForAll #-}
-
 -- | Tests for the type checker and evaluator in Core/IR/Typechecker.hs
 module CoreTypechecker where
 

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -113,7 +113,7 @@ test_eval_sub =
 --unit tests for cType
 shouldCheck ∷
   ∀ primTy primVal.
-  (Show primTy, Eq primTy, Show primVal, Eq primVal) ⇒
+  (Show primTy, Show primVal, Eq primTy, Eq primVal) ⇒
   Parameterisation primTy primVal →
   IR.Term primTy primVal →
   IR.Annotation primTy primVal →
@@ -125,7 +125,7 @@ shouldCheck param term ann =
 --unit tests for iType
 shouldInfer ∷
   ∀ primTy primVal.
-  (Show primTy, Eq primTy, Show primVal, Eq primVal) ⇒
+  (Show primTy, Show primVal, Eq primTy, Eq primVal) ⇒
   Parameterisation primTy primVal →
   IR.Elim primTy primVal →
   IR.Annotation primTy primVal →
@@ -136,7 +136,7 @@ shouldInfer param term ann =
 
 shouldEval ∷
   ∀ primTy primVal.
-  (Show primTy, Eq primTy, Show primVal, Eq primVal) ⇒
+  (Show primTy, Show primVal, Eq primTy, Eq primVal) ⇒
   Parameterisation primTy primVal →
   IR.Term primTy primVal →
   IR.Value primTy primVal →

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -9,26 +9,38 @@ import Juvix.Library hiding (identity)
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
 
-{- type Term = IR.Term primTy primVal
+type NatTerm = IR.Term NatTy NatVal
 
-type Elim = IR.Elim primTy primVal
+type NatElim = IR.Elim NatTy NatVal
 
-type Value = IR.Value primTy primVal
+type NatValue = IR.Value NatTy NatVal
 
-type Annotation = IR.Annotation primTy primVal
- -}
-identity ∷ IR.Term NatTy NatVal
+type NatAnnotation = IR.Annotation NatTy NatVal
+
+type UnitTerm = IR.Term UnitTy UnitVal
+
+type UnitElim = IR.Elim UnitTy UnitVal
+
+type UnitValue = IR.Value UnitTy UnitVal
+
+type UnitAnnotation = IR.Annotation UnitTy UnitVal
+
+identity ∷ ∀ primTy primVal. IR.Term primTy primVal
 identity = IR.Lam (IR.Elim (IR.Bound 0))
 
-identityCompTy ∷ IR.Annotation NatTy NatVal
-identityCompTy =
+identityNatCompTy ∷ NatAnnotation
+identityNatCompTy =
   (SNat 1, IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
 
-identityContTy ∷ IR.Annotation NatTy NatVal
-identityContTy =
+identityUnitCompTy ∷ UnitAnnotation
+identityUnitCompTy =
+  (SNat 1, IR.VPi (SNat 1) (IR.VPrimTy TUnit) (const (IR.VPrimTy TUnit)))
+
+identityNatContTy ∷ NatAnnotation
+identityNatContTy =
   (SNat 0, IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
 
-identityApplication ∷ IR.Term NatTy NatVal
+identityApplication ∷ NatTerm
 identityApplication =
   IR.Elim
     ( IR.App
@@ -40,14 +52,17 @@ identityApplication =
         (IR.Elim (IR.Prim (Natural 1)))
     )
 
-natTy ∷ IR.Annotation NatTy NatVal
+natTy ∷ NatAnnotation
 natTy = (SNat 1, IR.VPrimTy Nat)
 
 test_identity_computational ∷ T.TestTree
-test_identity_computational = shouldCheck identity identityCompTy
+test_identity_computational = shouldCheck identity identityNatCompTy
+
+test_identity_unit_computational ∷ T.TestTree
+test_identity_unit_computational = shouldCheck identity identityUnitCompTy
 
 test_identity_contemplation ∷ T.TestTree
-test_identity_contemplation = shouldCheck identity identityContTy
+test_identity_contemplation = shouldCheck identity identityNatContTy
 
 test_identity_application ∷ T.TestTree
 test_identity_application = shouldCheck identityApplication natTy
@@ -90,26 +105,26 @@ test_eval_sub =
     (IR.VPrim (Natural 3))
 
 --unit tests for cType
-shouldCheck ∷ IR.Term → IR.Annotation → T.TestTree
+--shouldCheck ∷ NatTerm -> NatAnnotation -> T.TestTree --forall primTy primVal . IR.Term primTy primVal → IR.Annotation primTy primVal → T.TestTree
 shouldCheck term ann =
   T.testCase (show term <> " should check as type " <> show ann) $
-    IR.cType naturals 0 [] term ann T.@=? Right ()
+    IR.cType 0 [] term ann T.@=? Right ()
 
 --unit tests for iType
-shouldInfer ∷ IR.Elim → IR.Annotation → T.TestTree
+shouldInfer ∷ ∀ primTy primVal. IR.Elim primTy primVal → IR.Annotation primTy primVal → T.TestTree
 shouldInfer term ann =
   T.testCase (show term <> " should infer to type " <> show ann) $
-    IR.iType0 naturals [] term T.@=? Right ann
+    IR.iType0 [] term T.@=? Right ann
 
-shouldEval ∷ IR.Term → IR.Value → T.TestTree
+shouldEval ∷ ∀ primTy primVal. IR.Term primTy primVal → IR.Value primTy primVal → T.TestTree
 shouldEval term res =
   T.testCase (show term <> " should evaluate to " <> show res) $
-    IR.cEval naturals term IR.initEnv T.@=? res
+    IR.cEval term IR.initEnv T.@=? res
 
-one ∷ IR.Term
+one ∷ ∀ primTy primVal. IR.Term primTy primVal
 one = IR.Lam $ IR.Lam $ IR.Elim $ IR.App (IR.Bound 1) (IR.Elim (IR.Bound 0))
 
-oneCompTy ∷ IR.Annotation NatTy NatVal
+oneCompTy ∷ NatAnnotation
 oneCompTy =
   ( SNat 1,
     IR.VPi
@@ -118,14 +133,14 @@ oneCompTy =
       (const (IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
   )
 
-two ∷ IR.Term
+two ∷ ∀ primTy primVal. IR.Term primTy primVal
 two =
   IR.Lam
     $ IR.Lam
     $ IR.Elim
     $ IR.App (IR.Bound 1) (IR.Elim (IR.App (IR.Bound 1) (IR.Elim (IR.Bound 0))))
 
-twoCompTy ∷ IR.Annotation NatTy NatVal
+twoCompTy ∷ NatAnnotation
 twoCompTy =
   ( SNat 1,
     IR.VPi


### PR DESCRIPTION
- Make formatter work on more files.
- Change ```naturals``` to ```nat``` for easier/more consistent naming of primitive types. The parameterisation functions should all be named as the data type without ```Ty```, e.g., NatTy's parameterisation is ```nat```, UnitTy's parameterisation is ```unit```.
- Add unit type as a primitive type.
  - add ```param``` as an input to the test generators(shouldCheck, shouldInfer, shouldEval)
  - add ```shouldParsePrim``` test generator function for testing parsing of primitive types.


May use [this](https://hackage.haskell.org/package/capability-0.2.0.0/docs/Capability-Reader.html) (as suggested by @cwgoes ) to avoid threading the parameterisation through all functions in another commit.
