### PR TITLE
Updated CI so an issue in stack test does not run forever

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           paths:
             - "~/.stack"
             - ".stack-work"
- 
+
   test_suite:
     docker:
       - image: cryptiumlabs/juvix-ci
@@ -37,6 +37,7 @@ jobs:
       - run:
           name: Run tests
           command: stack test
+          no_output_timeout: 1200
 
 workflows:
   version: 2.1

--- a/src/Juvix/Library.hs
+++ b/src/Juvix/Library.hs
@@ -82,7 +82,7 @@ traverseM ∷
   f (m a2)
 traverseM f = fmap join . traverse f
 
-instance Show ((->) a b) where
+instance Show (a → b) where
   show _ = "fun"
 
 newtype Symbol = Sym Text deriving (Eq, Hashable)


### PR DESCRIPTION
Fixed circle ci so it doesn't run forever when pipe 11 is filled