### PR TITLE
Erasure contd.

### DIFF
--- a/src/Juvix/Core/Erasure/Algorithm.hs
+++ b/src/Juvix/Core/Erasure/Algorithm.hs
@@ -64,7 +64,7 @@ eraseTerm parameterisation term usage ty =
         body ← eraseTerm parameterisation body bodyUsage retTyBody
         -- If argument is not used, just return the erased body.
         -- Otherwise, if argument is used, return a lambda function.
-        pure (if usage <> argUsage == Core.SNat 0 then body else Erased.Lam name body)
+        pure (if usage <.> argUsage == Core.SNat 0 then body else Erased.Lam name body)
       Core.Elim elim →
         case elim of
           Core.Var n → pure (Erased.Var n)

--- a/src/Juvix/Core/Erasure/Types.hs
+++ b/src/Juvix/Core/Erasure/Types.hs
@@ -1,30 +1,35 @@
 module Juvix.Core.Erasure.Types where
 
 import qualified Juvix.Core.Erased as Erased
+import qualified Juvix.Core.IR.Types as IR
 import Juvix.Library hiding (empty)
 
-data Env primTy
+data Env primTy primVal
   = Env
       { typeAssignment ∷ Erased.TypeAssignment primTy,
+        context ∷ IR.Context primTy primVal,
         nextName ∷ Int,
         nameStack ∷ [Int]
       }
   deriving (Show, Eq, Generic)
 
-newtype EnvErasure primTy a = EnvEra (ExceptT ErasureError (State (Env primTy)) a)
+newtype EnvErasure primTy primVal a = EnvEra (ExceptT ErasureError (State (Env primTy primVal)) a)
   deriving (Functor, Applicative, Monad)
   deriving
     (HasState "typeAssignment" (Erased.TypeAssignment primTy))
-    via Field "typeAssignment" () (MonadState (ExceptT ErasureError (State (Env primTy))))
+    via Field "typeAssignment" () (MonadState (ExceptT ErasureError (State (Env primTy primVal))))
+  deriving
+    (HasState "context" (IR.Context primTy primVal))
+    via Field "context" () (MonadState (ExceptT ErasureError (State (Env primTy primVal))))
   deriving
     (HasState "nextName" Int)
-    via Field "nextName" () (MonadState (ExceptT ErasureError (State (Env primTy))))
+    via Field "nextName" () (MonadState (ExceptT ErasureError (State (Env primTy primVal))))
   deriving
     (HasState "nameStack" [Int])
-    via Field "nameStack" () (MonadState (ExceptT ErasureError (State (Env primTy))))
+    via Field "nameStack" () (MonadState (ExceptT ErasureError (State (Env primTy primVal))))
   deriving
     (HasThrow "erasureError" ErasureError)
-    via MonadError (ExceptT ErasureError (MonadState (State (Env primTy))))
+    via MonadError (ExceptT ErasureError (MonadState (State (Env primTy primVal))))
 
 data ErasureError
   = Unsupported

--- a/src/Juvix/Core/Erasure/Types.hs
+++ b/src/Juvix/Core/Erasure/Types.hs
@@ -29,4 +29,5 @@ newtype EnvErasure primTy a = EnvEra (ExceptT ErasureError (State (Env primTy)) 
 data ErasureError
   = Unsupported
   | CannotEraseZeroUsageTerm
+  | InternalError Text
   deriving (Show, Eq, Generic)

--- a/src/Juvix/Core/IR/Typechecker.hs
+++ b/src/Juvix/Core/IR/Typechecker.hs
@@ -175,7 +175,7 @@ cType p ii g (Lam s) ann =
         ((Local ii, (sig <.> pi, ty)) : g) -- put s in the context with usage sig*pi
         (cSubst 0 (Free (Local ii)) s) -- x (varType) in context S with sigma*pi usage.
         (sig, ty' (vfree (Local ii))) -- is of type M (usage sigma) in context T
-    _ → throwError $ show (snd ann) <> " is not a function type but should be."
+    _ → throwError $ show (snd ann) <> " is not a function type but should be - while checking " <> show (Lam s)
 --
 cType p ii g (Elim e) ann = do
   ann' ← iType p ii g e

--- a/test/Erasure.hs
+++ b/test/Erasure.hs
@@ -20,7 +20,24 @@ shouldEraseTo ∷
 shouldEraseTo parameterisation (term, usage, ty) erased =
   T.testCase
     (show (term, usage, ty) <> " should erase to " <> show erased)
-    ((fst |<< Erasure.erase parameterisation term usage ty) T.@=? Right erased)
+    ( Right erased
+        T.@=? ((fst |<< Erasure.erase parameterisation term usage ty))
+    )
 
 test_trivial_unit ∷ T.TestTree
 test_trivial_unit = shouldEraseTo unit (HR.Elim (HR.Prim Unit), SNat 1, HR.PrimTy TUnit) (Erased.Prim Unit)
+
+test_unused_arg ∷ T.TestTree
+test_unused_arg = shouldEraseTo unit (constTerm, SNat 1, constTy) (Erased.Lam "y" (Erased.Var "y"))
+
+constTerm ∷ HR.Term UnitTy UnitVal
+constTerm = HR.Lam "x" (HR.Lam "y" (HR.Elim (HR.Var "y")))
+
+constTy ∷ HR.Term UnitTy UnitVal
+constTy = HR.Pi (SNat 0) unitTy (HR.Lam "_" (HR.Pi (SNat 1) unitTy (HR.Lam "_" unitTy)))
+
+unitTerm ∷ HR.Term UnitTy UnitVal
+unitTerm = HR.Elim (HR.Prim Unit)
+
+unitTy ∷ HR.Term UnitTy UnitVal
+unitTy = HR.PrimTy TUnit

--- a/test/Erasure.hs
+++ b/test/Erasure.hs
@@ -43,22 +43,22 @@ identityTerm ∷ HR.Term UnitTy UnitVal
 identityTerm = HR.Lam "y" (HR.Elim (HR.Var "y"))
 
 identityTy ∷ HR.Term UnitTy UnitVal
-identityTy = HR.Pi (SNat 1) unitTy (HR.Lam "_" unitTy)
+identityTy = HR.Pi (SNat 1) unitTy unitTy
 
 appTerm ∷ HR.Term UnitTy UnitVal
 appTerm = HR.Lam "f" (HR.Lam "x" (HR.Elim (HR.App (HR.Var "f") (HR.Elim (HR.Var "x")))))
 
 appTy ∷ HR.Term UnitTy UnitVal
-appTy = HR.Pi (SNat 1) identityTy (HR.Lam "_" (HR.Pi (SNat 1) unitTy (HR.Lam "_" unitTy)))
+appTy = HR.Pi (SNat 1) identityTy (HR.Pi (SNat 1) unitTy unitTy)
 
 constTerm ∷ HR.Term UnitTy UnitVal
 constTerm = HR.Lam "x" identityTerm
 
 constTy ∷ HR.Term UnitTy UnitVal
-constTy = HR.Pi (SNat 0) unitTy (HR.Lam "_" identityTy)
+constTy = HR.Pi (SNat 0) unitTy identityTy
 
 constTy2 ∷ HR.Term UnitTy UnitVal
-constTy2 = HR.Pi (SNat 0) identityTy (HR.Lam "_" identityTy)
+constTy2 = HR.Pi (SNat 0) identityTy identityTy
 
 unitTerm ∷ HR.Term UnitTy UnitVal
 unitTerm = HR.Elim (HR.Prim Unit)

--- a/test/Erasure.hs
+++ b/test/Erasure.hs
@@ -30,6 +30,9 @@ test_trivial_unit = shouldEraseTo unit (HR.Elim (HR.Prim Unit), SNat 1, HR.PrimT
 test_unused_arg ∷ T.TestTree
 test_unused_arg = shouldEraseTo unit (constTerm, SNat 1, constTy) (Erased.Lam "y" (Erased.Var "y"))
 
+test_used_arg ∷ T.TestTree
+test_used_arg = shouldEraseTo unit (appTerm, SNat 1, appTy) (Erased.Lam "f" (Erased.Lam "x" (Erased.App (Erased.Var "f") (Erased.Var "x"))))
+
 test_app_unused_arg ∷ T.TestTree
 test_app_unused_arg = shouldEraseTo unit (HR.Elim (HR.App (HR.Ann (SNat 1) constTerm constTy) (HR.Elim (HR.Prim Unit))), SNat 1, identityTy) (Erased.Lam "y" (Erased.Var "y"))
 
@@ -38,6 +41,12 @@ identityTerm = HR.Lam "y" (HR.Elim (HR.Var "y"))
 
 identityTy ∷ HR.Term UnitTy UnitVal
 identityTy = HR.Pi (SNat 1) unitTy (HR.Lam "_" unitTy)
+
+appTerm ∷ HR.Term UnitTy UnitVal
+appTerm = HR.Lam "f" (HR.Lam "x" (HR.Elim (HR.App (HR.Var "f") (HR.Elim (HR.Var "x")))))
+
+appTy ∷ HR.Term UnitTy UnitVal
+appTy = HR.Pi (SNat 1) identityTy (HR.Lam "_" (HR.Pi (SNat 1) unitTy (HR.Lam "_" unitTy)))
 
 constTerm ∷ HR.Term UnitTy UnitVal
 constTerm = HR.Lam "x" identityTerm

--- a/test/Erasure.hs
+++ b/test/Erasure.hs
@@ -30,11 +30,20 @@ test_trivial_unit = shouldEraseTo unit (HR.Elim (HR.Prim Unit), SNat 1, HR.PrimT
 test_unused_arg ∷ T.TestTree
 test_unused_arg = shouldEraseTo unit (constTerm, SNat 1, constTy) (Erased.Lam "y" (Erased.Var "y"))
 
+test_app_unused_arg ∷ T.TestTree
+test_app_unused_arg = shouldEraseTo unit (HR.Elim (HR.App (HR.Ann (SNat 1) constTerm constTy) (HR.Elim (HR.Prim Unit))), SNat 1, identityTy) (Erased.Lam "y" (Erased.Var "y"))
+
+identityTerm ∷ HR.Term UnitTy UnitVal
+identityTerm = HR.Lam "y" (HR.Elim (HR.Var "y"))
+
+identityTy ∷ HR.Term UnitTy UnitVal
+identityTy = HR.Pi (SNat 1) unitTy (HR.Lam "_" unitTy)
+
 constTerm ∷ HR.Term UnitTy UnitVal
-constTerm = HR.Lam "x" (HR.Lam "y" (HR.Elim (HR.Var "y")))
+constTerm = HR.Lam "x" identityTerm
 
 constTy ∷ HR.Term UnitTy UnitVal
-constTy = HR.Pi (SNat 0) unitTy (HR.Lam "_" (HR.Pi (SNat 1) unitTy (HR.Lam "_" unitTy)))
+constTy = HR.Pi (SNat 0) unitTy (HR.Lam "_" identityTy)
 
 unitTerm ∷ HR.Term UnitTy UnitVal
 unitTerm = HR.Elim (HR.Prim Unit)

--- a/test/Erasure.hs
+++ b/test/Erasure.hs
@@ -36,6 +36,9 @@ test_used_arg = shouldEraseTo unit (appTerm, SNat 1, appTy) (Erased.Lam "f" (Era
 test_app_unused_arg ∷ T.TestTree
 test_app_unused_arg = shouldEraseTo unit (HR.Elim (HR.App (HR.Ann (SNat 1) constTerm constTy) (HR.Elim (HR.Prim Unit))), SNat 1, identityTy) (Erased.Lam "y" (Erased.Var "y"))
 
+test_unused_function ∷ T.TestTree
+test_unused_function = shouldEraseTo unit (HR.Elim (HR.App (HR.Ann (SNat 1) constTerm constTy2) identityTerm), SNat 1, identityTy) (Erased.Lam "y" (Erased.Var "y"))
+
 identityTerm ∷ HR.Term UnitTy UnitVal
 identityTerm = HR.Lam "y" (HR.Elim (HR.Var "y"))
 
@@ -53,6 +56,9 @@ constTerm = HR.Lam "x" identityTerm
 
 constTy ∷ HR.Term UnitTy UnitVal
 constTy = HR.Pi (SNat 0) unitTy (HR.Lam "_" identityTy)
+
+constTy2 ∷ HR.Term UnitTy UnitVal
+constTy2 = HR.Pi (SNat 0) identityTy (HR.Lam "_" identityTy)
 
 unitTerm ∷ HR.Term UnitTy UnitVal
 unitTerm = HR.Elim (HR.Prim Unit)


### PR DESCRIPTION
Closes https://github.com/cryptiumlabs/juvix/issues/160

This seems to work but it is a bit messy. We'll need to either fuse the core typechecker & erasure in order to avoid doing duplicate typechecking work here, or pass along type information for subterms somehow.