### PR TITLE
Thealmarty/add more tests

### DIFF
--- a/src/Juvix/Core/Parameterisations/All.hs
+++ b/src/Juvix/Core/Parameterisations/All.hs
@@ -19,11 +19,13 @@ import Prelude (String)
 data AllTy
   = NatTy Naturals.NatTy
   | UnitTy Unit.UnitTy
+  deriving (Show, Eq)
 
 -- c: primitive constant and f: functions
 data AllVal
   = NatVal Naturals.NatVal
   | UnitVal Unit.UnitVal
+  deriving (Show, Eq)
 
 natTyToAll ∷ Naturals.NatTy → AllTy
 natTyToAll = NatTy

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -168,7 +168,7 @@ identityAppK =
     )
 
 -- (K: Nat -> Nat -> Nat 1) should type check to Nat -> Nat
-kApp1 :: NatElim
+kApp1 ∷ NatElim
 kApp1 =
   IR.App
     ( IR.Ann
@@ -182,8 +182,8 @@ kApp1 =
     )
     (IR.Elim (IR.Prim (Natural 1)))
 
-natToNatTy :: NatAnnotation
-natToNatTy = 
+natToNatTy ∷ NatAnnotation
+natToNatTy =
   (SNat 1, IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
 
 --K: (Nat -> Nat) -> Nat -> (Nat -> Nat) I:Nat -> Nat type checks to Nat -> (Nat -> Nat)
@@ -219,7 +219,6 @@ kAppICompTy =
       (IR.VPrimTy Nat)
       (const (IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
   )
-  
 
 {-
 -- Because S returns functions, it's not general because of the annotations.
@@ -307,9 +306,9 @@ test_identity_app_k ∷ T.TestTree
 test_identity_app_k = shouldInfer nat identityAppK kCompTy
 
 test_k_app_I ∷ T.TestTree
-test_k_app_I = shouldInfer nat kAppI kAppICompTy
+test_k_app_I = shouldCheck nat (IR.Elim kAppI) kAppICompTy
 
-test_k_app_1 :: T.TestTree
+test_k_app_1 ∷ T.TestTree
 test_k_app_1 = shouldInfer nat kApp1 natToNatTy
 
 --test_siii :: T.TestTree

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -167,6 +167,25 @@ identityAppK =
         )
     )
 
+-- (K: Nat -> Nat -> Nat 1) should type check to Nat -> Nat
+kApp1 :: NatElim
+kApp1 =
+  IR.App
+    ( IR.Ann
+        (SNat 1)
+        kcombinator
+        ( IR.Pi
+            (SNat 1)
+            (IR.PrimTy Nat)
+            (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat))
+        )
+    )
+    (IR.Elim (IR.Prim (Natural 1)))
+
+natToNatTy :: NatAnnotation
+natToNatTy = 
+  (SNat 1, IR.VPi (SNat 1) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
+
 --K: (Nat -> Nat) -> Nat -> (Nat -> Nat) I:Nat -> Nat type checks to Nat -> (Nat -> Nat)
 kAppI ∷ NatElim
 kAppI =
@@ -200,6 +219,7 @@ kAppICompTy =
       (IR.VPrimTy Nat)
       (const (IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
   )
+  
 
 {-
 -- Because S returns functions, it's not general because of the annotations.
@@ -229,7 +249,7 @@ scombinator =
                         (IR.Ann
                             (SNat 1)
                             (IR.Bound 2)
-                            () -- Annotation of x                  
+                            () -- Annotation of x
                         )
                         (IR.Elim (IR.Bound 0))
                     )
@@ -239,7 +259,7 @@ scombinator =
                     (IR.Ann
                         (SNat 1)
                         (IR.Bound 1)
-                        () -- Annotation of y                  
+                        () -- Annotation of y
                     )
                     (IR.Elim (IR.Bound 0))
                 )
@@ -288,6 +308,9 @@ test_identity_app_k = shouldInfer nat identityAppK kCompTy
 
 test_k_app_I ∷ T.TestTree
 test_k_app_I = shouldInfer nat kAppI kAppICompTy
+
+test_k_app_1 :: T.TestTree
+test_k_app_1 = shouldInfer nat kApp1 natToNatTy
 
 --test_siii :: T.TestTree
 --test_siii = shouldInfer all scombinator

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -333,8 +333,8 @@ test_identity_app_k ∷ T.TestTree
 test_identity_app_k = shouldInfer nat identityAppK kCompTy
 
 -- TODO investigate why this test fail.
-test_k_app_I ∷ T.TestTree
-test_k_app_I = shouldCheck nat (IR.Elim kAppI) kAppICompTy
+--test_k_app_I ∷ T.TestTree
+--test_k_app_I = shouldCheck nat (IR.Elim kAppI) kAppICompTy
 
 test_k_app_1 ∷ T.TestTree
 test_k_app_1 = shouldInfer nat kApp1 natToNatTy

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -2,7 +2,7 @@
 module CoreTypechecker where
 
 import qualified Juvix.Core.IR as IR
-import Juvix.Core.Parameterisations.All as All 
+import Juvix.Core.Parameterisations.All as All
 import Juvix.Core.Parameterisations.Naturals
 import Juvix.Core.Parameterisations.Unit
 import Juvix.Core.Types
@@ -12,18 +12,27 @@ import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
 
 type NatTerm = IR.Term NatTy NatVal
+
 type NatElim = IR.Elim NatTy NatVal
+
 type NatValue = IR.Value NatTy NatVal
+
 type NatAnnotation = IR.Annotation NatTy NatVal
 
 type UnitTerm = IR.Term UnitTy UnitVal
+
 type UnitElim = IR.Elim UnitTy UnitVal
+
 type UnitValue = IR.Value UnitTy UnitVal
+
 type UnitAnnotation = IR.Annotation UnitTy UnitVal
 
 type AllTerm = IR.Term AllTy AllVal
+
 type AllElim = IR.Elim AllTy AllVal
+
 type AllValue = IR.Value AllTy AllVal
+
 type AllAnnotation = IR.Annotation AllTy AllVal
 
 identity ∷ ∀ primTy primVal. IR.Term primTy primVal
@@ -149,19 +158,21 @@ identityAppK =
     )
 
 --K: (Nat -> Nat) -> Nat -> (Nat -> Nat) I:Nat -> Nat type checks to Nat -> (Nat -> Nat)
-kAppI :: NatElim
+kAppI ∷ NatElim
 kAppI =
   IR.App
-    (IR.Ann
-      (SNat 1)
-      kcombinator
-      (IR.Pi 
-        (SNat 1) 
-        (IR.Pi 
-            (SNat 1) 
-            (IR.PrimTy Nat)
-            (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat))) 
-        (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat)))
+    ( IR.Ann
+        (SNat 1)
+        kcombinator
+        ( IR.Pi
+            (SNat 1)
+            ( IR.Pi
+                (SNat 1)
+                (IR.PrimTy Nat)
+                (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat))
+            )
+            (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat))
+        )
     )
     ( IR.Elim
         ( IR.Ann
@@ -171,15 +182,14 @@ kAppI =
         )
     )
 
-kAppICompTy :: NatAnnotation
+kAppICompTy ∷ NatAnnotation
 kAppICompTy =
   ( SNat 1,
-  IR.VPi
-    (SNat 1)
-    (IR.VPrimTy Nat)
-    (const (IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
+    IR.VPi
+      (SNat 1)
+      (IR.VPrimTy Nat)
+      (const (IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
   )
-
 
 {- scombinator ∷ ∀ primTy primVal. IR.Term primTy primVal -- S = \x.\y.\z. (xz) (yz)
 scombinator =
@@ -188,7 +198,7 @@ scombinator =
         ( IR.Lam --z (Bound 0)
             ( IR.App
                 (IR.Ann
-                    (SNat 1)    
+                    (SNat 1)
                     ( IR.App
                         (IR.Ann
                             (SNat 1)
@@ -204,14 +214,14 @@ scombinator =
         )
     )
 
--- For example, S (KSK) = (KK) (SK) = K:Nat-> Nat-> Nat 
--- (x = K that takes inputs 
---     (1) K, with type signature of z, and 
+-- For example, S (KSK) = (KK) (SK) = K:Nat-> Nat-> Nat
+-- (x = K that takes inputs
+--     (1) K, with type signature of z, and
 --     (2) SK, the S takes in K and 2 Nats, and has the signature (Nat -> Nat -> Nat) -> Nat -> Nat -> Nat,
 --             the K has the type signature of z. So SK has the signature of Nat -> Nat -> Nat
 -- so x has the signature of (Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat)
--- (y = S that takes in K and 2 Nats and returns a Nat:) (Nat -> Nat-> Nat) -> Nat -> Nat -> Nat 
--- (z = K:) Nat -> Nat -> Nat 
+-- (y = S that takes in K and 2 Nats and returns a Nat:) (Nat -> Nat-> Nat) -> Nat -> Nat -> Nat
+-- (z = K:) Nat -> Nat -> Nat
 -- (returns z) -> Nat -> Nat -> Nat
 -- To sum, type signature of S in this example is:
 -- ((Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat)) ->
@@ -225,7 +235,7 @@ sCompNatTy =
       (IR.VPrimTy Nat)
       (const (IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
   )
- -}    
+ -}
 test_identity_computational ∷ T.TestTree
 test_identity_computational = shouldCheck nat identity identityNatCompTy
 
@@ -250,7 +260,7 @@ test_kcombinator_computational = shouldCheck nat kcombinator kCompTy
 test_identity_app_k ∷ T.TestTree
 test_identity_app_k = shouldInfer nat identityAppK kCompTy
 
-test_k_app_I ::T.TestTree
+test_k_app_I ∷ T.TestTree
 test_k_app_I = shouldInfer nat kAppI kAppICompTy
 
 --test_siii :: T.TestTree

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -50,6 +50,33 @@ identityNatContTy ∷ NatAnnotation
 identityNatContTy =
   (SNat 0, IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat)))
 
+-- dependent identity function, a : * -> a -> a
+depIdentity ∷ ∀ primTy primVal. IR.Term primTy primVal
+depIdentity =
+  IR.Lam
+    ( IR.Lam
+        ( IR.Elim
+            ( IR.Ann
+                (SNat 0)
+                (IR.Elim (IR.Bound 0))
+                (IR.Elim (IR.Bound 1))
+            )
+        )
+    )
+
+{- TODO
+depIdentityCompTy ∷ AllAnnotation
+depIdentityCompTy =
+  ( SNat 0,
+    IR.VPi
+      (SNat 0)
+      (IR.VStar 0)
+      ( IR.vapp
+          All.all
+          (IR.VLam (IR.VPrimTy))
+      )
+  )
+ -}
 identityApplication ∷ NatTerm
 identityApplication =
   IR.Elim
@@ -305,6 +332,7 @@ test_kcombinatorUnit_computational = shouldCheck All.all kcombinator kCompTyWith
 test_identity_app_k ∷ T.TestTree
 test_identity_app_k = shouldInfer nat identityAppK kCompTy
 
+-- TODO investigate why this test fail.
 test_k_app_I ∷ T.TestTree
 test_k_app_I = shouldCheck nat (IR.Elim kAppI) kAppICompTy
 

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -176,12 +176,12 @@ kAppI =
         kcombinator
         ( IR.Pi
             (SNat 1)
+            (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat))
             ( IR.Pi
                 (SNat 1)
                 (IR.PrimTy Nat)
                 (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat))
             )
-            (IR.Pi (SNat 1) (IR.PrimTy Nat) (IR.PrimTy Nat))
         )
     )
     ( IR.Elim

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -125,7 +125,7 @@ kCompTy =
   )
 
 -- Nat -> () -> Nat
-kCompTyWithUnit :: AllAnnotation
+kCompTyWithUnit ∷ AllAnnotation
 kCompTyWithUnit =
   ( SNat 1,
     IR.VPi

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -201,7 +201,23 @@ kAppICompTy =
       (const (IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
   )
 
-{- scombinator ∷ ∀ primTy primVal. IR.Term primTy primVal -- S = \x.\y.\z. (xz) (yz)
+{-
+-- Because S returns functions, it's not general because of the annotations.
+-- For example, S (KSK) = (KK) (SK) = K:Nat-> Nat-> Nat
+-- this S takes in KSK, and has x and y annotated as follows:
+-- (x = K that takes inputs
+--     (1) K, with type signature of z, and
+--     (2) SK, the S takes in K and 2 Nats, and has the signature (Nat -> Nat -> Nat) -> Nat -> Nat -> Nat,
+--             the K has the type signature of z. So SK has the signature of Nat -> Nat -> Nat
+-- so x has the signature of (Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat)
+-- (y = S that takes in K and 2 Nats and returns a Nat:) (Nat -> Nat-> Nat) -> Nat -> Nat -> Nat
+-- (z = K:) Nat -> Nat -> Nat
+-- (returns z) -> Nat -> Nat -> Nat
+-- To sum, type signature of S in this example is:
+-- ((Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat)) ->
+-- ((Nat -> Nat -> Nat) -> Nat -> Nat -> Nat)
+-- (Nat -> Nat -> Nat)
+scombinator ∷ ∀ primTy primVal. IR.Term primTy primVal -- S = \x.\y.\z. (xz) (yz)
 scombinator =
   IR.Lam --x (Bound 2)
     ( IR.Lam --y (Bound 1)
@@ -213,27 +229,24 @@ scombinator =
                         (IR.Ann
                             (SNat 1)
                             (IR.Bound 2)
-                            ())
+                            () -- Annotation of x                  
+                        )
                         (IR.Elim (IR.Bound 0))
-                        ))
-                        ( IR.App
-                            (IR.Bound 1) --TODO Annotate this
-                            (IR.Elim (IR.Bound 0))
+                    )
+                    () -- Annotation of the outside App
+                )
+                ( IR.App
+                    (IR.Ann
+                        (SNat 1)
+                        (IR.Bound 1)
+                        () -- Annotation of y                  
+                    )
+                    (IR.Elim (IR.Bound 0))
                 )
             )
         )
     )
 
--- For example, S (KSK) = (KK) (SK) = K:Nat-> Nat-> Nat
--- (x = K that takes inputs
---     (1) K, with type signature of z, and
---     (2) SK, the S takes in K and 2 Nats, and has the signature (Nat -> Nat -> Nat) -> Nat -> Nat -> Nat,
---             the K has the type signature of z. So SK has the signature of Nat -> Nat -> Nat
--- so x has the signature of (Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat)
--- (y = S that takes in K and 2 Nats and returns a Nat:) (Nat -> Nat-> Nat) -> Nat -> Nat -> Nat
--- (z = K:) Nat -> Nat -> Nat
--- (returns z) -> Nat -> Nat -> Nat
--- To sum, type signature of S in this example is:
 -- ((Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat) -> (Nat -> Nat -> Nat)) ->
 -- ((Nat -> Nat -> Nat) -> Nat -> Nat -> Nat)
 -- (Nat -> Nat -> Nat)

--- a/test/CoreTypechecker.hs
+++ b/test/CoreTypechecker.hs
@@ -124,6 +124,16 @@ kCompTy =
       (const (IR.VPi (SNat 0) (IR.VPrimTy Nat) (const (IR.VPrimTy Nat))))
   )
 
+-- Nat -> () -> Nat
+kCompTyWithUnit :: AllAnnotation
+kCompTyWithUnit =
+  ( SNat 1,
+    IR.VPi
+      (SNat 1)
+      (IR.VPrimTy (All.NatTy Nat))
+      (const (IR.VPi (SNat 0) (IR.VPrimTy (All.UnitTy TUnit)) (const (IR.VPrimTy (All.NatTy Nat)))))
+  )
+
 -- I:(Nat->Nat->Nat)->(Nat->Nat->Nat) K:(Nat->Nat->Nat) should type check to (Nat->Nat->Nat)
 identityAppK ∷ NatElim
 identityAppK =
@@ -256,6 +266,9 @@ test_identity_app_I = shouldInfer nat identityAppI identityNatCompTy
 
 test_kcombinator_computational ∷ T.TestTree
 test_kcombinator_computational = shouldCheck nat kcombinator kCompTy
+
+test_kcombinatorUnit_computational ∷ T.TestTree
+test_kcombinatorUnit_computational = shouldCheck All.all kcombinator kCompTyWithUnit
 
 test_identity_app_k ∷ T.TestTree
 test_identity_app_k = shouldInfer nat identityAppK kCompTy


### PR DESCRIPTION
This PR made progress towards #161 :
Add tests making use of `allTy`.
Add more tests of the K combinator.
Test of `KAppI` still fail, to investigate.
Adding S combinator, to be finished to test.
Add dependent identity function `depIdentity`, need to finish annotation to test.