### PR TITLE
Generating Documentation for a brief overview in the org format

### DIFF
--- a/doc/Code/generate.lisp
+++ b/doc/Code/generate.lisp
@@ -12,7 +12,7 @@
 ;; Maybe type
 ;; -----------------------------------------------------------------------------
 
-;; todo better type it
+;; TODO better type it
 (defconstant +nothing+ :none)
 
 (defstruct just val)
@@ -46,6 +46,12 @@
   (alias +nothing+ :type maybe))
 
 ;; -----------------------------------------------------------------------------
+;; Program Constants
+;; -----------------------------------------------------------------------------
+
+(defparameter *acceptable-extensions* (fset:set "hs"))
+
+;; -----------------------------------------------------------------------------
 ;; Main Functionality
 ;; -----------------------------------------------------------------------------
 
@@ -55,21 +61,49 @@
         (sub-dirs (uiop:subdirectories directory)))
     3))
 
+
+;; -----------------------------------------------------------------------------
+;; Org Generation
+;; -----------------------------------------------------------------------------
+
+;; TODO parameterize this over the project name and language!
+(defun relevent-imports (lines conflict-map)
+  (let ((imports (remove-if (complement (lambda (x) (uiop:string-prefix-p "import" x)))
+                            lines)))
+    ))
+
+
+;; -----------------------------------------------------------------------------
+;; Conflict Map and Haskell Import Conversion
+;; -----------------------------------------------------------------------------
+
+
+(defun conflict-map-to-haskell-import (conflict-map)
+  (fset:m))
+
+;; TODO Parameterize this much better
+(defun convert-path (file &optional (dir-before-lirbary "src"))
+  
+  )
+
+
 ;; -----------------------------------------------------------------------------
 ;; Getting Directory and File lists
 ;; -----------------------------------------------------------------------------
-
 
 (defun get-directory-info (directory)
   (let* ((annote-1     (files-and-dirs directory))
          (conflict-map (construct-file-alias-map (lose-dir-information annote-1))))
     (alias-file-info annote-1 conflict-map)))
 
-(defun files-and-dirs (directory)
+(defun files-and-dirs (directory &optional (valid-extensions *acceptable-extensions*))
   "recursively grabs the file and directories
 forming a list of org-directory and file info"
-  (let* ((files          (uiop:directory-files directory))
-         (sub-dirs       (uiop:subdirectories  directory))
+  (let* ((sub-dirs       (uiop:subdirectories  directory))
+         (files          (remove-if (complement (lambda (x)
+                                                  (fset:@ valid-extensions
+                                                          (pathname-type x))))
+                                    (uiop:directory-files directory)))
          (dirs-annotated (mapcar (lambda (dir)
                                    (let* ((name  (file-name dir))
                                           (file? (find-if
@@ -216,14 +250,15 @@ Returns a string that reconstructs the unique identifier for the file"
           ((= extra-context 1)
            name)
           (t
-           (let* ((disambigous-path   (last (pathname-directory file)
-                                            (1- extra-context)))
-                  (reconstructed-path (butlast (mapcan (lambda (s) (list s "/"))
-                                                       (append disambigous-path
-                                                               (list name))))))
-             (apply #'concatenate 'string reconstructed-path))))))
+           (let ((disambigous-path (last (pathname-directory file)
+                                         (1- extra-context))))
+             (reconstruct-path (append disambigous-path (list name))))))))
 
-
+(defun reconstruct-path (xs &optional (connector "/"))
+  (apply #'concatenate
+         'string
+         (butlast (mapcan (lambda (s) (list s connector))
+                          xs))))
 ;; -----------------------------------------------------------------------------
 ;; Tests
 ;; -----------------------------------------------------------------------------

--- a/doc/Code/generate.lisp
+++ b/doc/Code/generate.lisp
@@ -78,7 +78,7 @@
                                 text)
                           (rec level (cdr dirs))))
                        (t
-                        (let ((text (generate-headline-directory (car dirs)
+                        (let ((text (generate-headlines-directory (car dirs)
                                                                  haskell-conflict-map
                                                                  level)))
                           (mapc (lambda (line)
@@ -452,7 +452,7 @@ Returns a string that reconstructs the unique identifier for the file"
 
 ;; (get-directory-info "../../holder/")
 
-;; (files-and-dirs "../../holder/src/")
+;; (files-and-dirs "../../src/")
 
 ;; (construct-file-alias-map
 ;;  (lose-dir-information

--- a/doc/Code/generate.lisp
+++ b/doc/Code/generate.lisp
@@ -1,0 +1,15 @@
+(ql:quickload "cl-org-mode")
+
+(asdf:load-system :uiop)
+
+(defpackage #:code-generation
+  (:use #:common-lisp))
+
+(in-package :code-generation)
+
+;; (uiop:directory-files "../../holder/")
+
+(defun generate-org-file (directory)
+  (let ((files    (uiop:directory-files directory))
+        (sub-dirs (uiop:subdirectories directory)))
+    ))

--- a/doc/Code/generate.lisp
+++ b/doc/Code/generate.lisp
@@ -209,7 +209,9 @@ that match the project name"
 
 (defun module-comments (file-lines)
   (let* ((module-comments
-           (take-until (lambda (x) (uiop:string-prefix-p "module" x)) file-lines))
+           (remove-if (lambda (x)
+                        (uiop:string-prefix-p "{-#" x))
+            (take-until (lambda (x) (uiop:string-prefix-p "module" x)) file-lines)))
          (special (car module-comments))
          (valid-module (if special
                            (uiop:string-prefix-p "-- |" special)

--- a/doc/Code/generate.lisp
+++ b/doc/Code/generate.lisp
@@ -210,7 +210,7 @@ that match the project name"
 (defun module-comments (file-lines)
   (let* ((module-comments
            (remove-if (lambda (x)
-                        (uiop:string-prefix-p "{-#" x))
+                        (or (uiop:string-prefix-p "{-#" x) (equal "" x)))
             (take-until (lambda (x) (uiop:string-prefix-p "module" x)) file-lines)))
          (special (car module-comments))
          (valid-module (if special

--- a/doc/Code/generate.lisp
+++ b/doc/Code/generate.lisp
@@ -1,8 +1,8 @@
-(ql:quickload "cl-org-mode")
-(ql:quickload "trivia")
-(ql:quickload "fset")
-
-(asdf:load-system :uiop)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (ql:quickload "cl-org-mode")
+  (ql:quickload "trivia")
+  (ql:quickload "fset")
+  (asdf:load-system :uiop))
 
 (defpackage #:code-generation
   (:use #:common-lisp))
@@ -10,7 +10,10 @@
 (in-package :code-generation)
 
 ;; (uiop:directory-files "../../holder/")
-;; Maybe type -----------------------------------------------
+;; -----------------------------------------------------------------------------
+;; Maybe type
+;; -----------------------------------------------------------------------------
+
 ;; todo better type it
 (defconstant +nothing+ :none)
 
@@ -21,7 +24,10 @@
       (eql :none)
       (satisfies just-p)))
 
-;; Directory and file types ---------------------------------
+;; -----------------------------------------------------------------------------
+;; Directory and file types
+;; -----------------------------------------------------------------------------
+
 (defstruct org-directory
   ;; some directories have a file that re-export things
   (file +nothing+ :type maybe)
@@ -32,9 +38,112 @@
   (path  ""        :type pathname)
   (alias +nothing+ :type maybe))
 
+;; -----------------------------------------------------------------------------
+;; Main Functionality
+;; -----------------------------------------------------------------------------
 
 (defun generate-org-file (directory)
   ;; (labels ((rec (directory conflicts))))
   (let ((files    (uiop:directory-files directory))
         (sub-dirs (uiop:subdirectories directory)))
-    ))
+    3))
+
+;; -----------------------------------------------------------------------------
+;; Getting Directory and File lists
+;; -----------------------------------------------------------------------------
+
+
+(defun files-and-dirs (directroy)
+  "rec"
+  2)
+
+;; -----------------------------------------------------------------------------
+;; Handling Conflicting Files
+;; -----------------------------------------------------------------------------
+
+(defun consturct-file-alias-map (files)
+  "finds any files that share the same identifier
+and returns a map of files to their alias"
+  (flet ((add-file (map file)
+           (let* ((name   (file-name file))
+                  (lookup (fset:lookup map name))) ; returns nil if none found
+             (fset:with map name (cons file lookup))))
+         (add-conflicts (map key conflicting-files)
+           (declare (ignore key))
+           (if (cdr conflicting-files)
+               (fset:map-union map
+                               (disambiguate-files conflicting-files
+                                                   :all-conflicts t))
+               map)))
+    (let* ((conflict-map
+             (reduce #'add-file files :initial-value (fset:empty-map))))
+      (fset:reduce #'add-conflicts conflict-map :initial-value (fset:empty-map)))))
+
+
+;; may do the job of consturct-file-alias-map, however this algorithm is slow
+;; for a large amount of files
+(defun disambiguate-files (file-list &key all-conflicts)
+  "takes a list of files and returns a map from
+the file name to their unique identifier"
+  (labels ((rec (remaining-conflicts unique-map dir-path-length)
+             (let* ((file-alias   (mapcar (lambda (x)
+                                            (list
+                                             x
+                                             (file-name x dir-path-length)))
+                                          remaining-conflicts))
+                    (conflict-set (remove-if (lambda (x)
+                                               (not (member-if
+                                                     (lambda (y)
+                                                       (and (equalp (cadr x) (cadr y))
+                                                            (not (equalp x y))))
+                                                     file-alias)))
+                                             file-alias))
+                    (non-conflict (remove-if (lambda (x) (member x conflict-set))
+                                             file-alias))
+                    (updated-map  (reduce (lambda (map alias-alist)
+                                            (fset:with map
+                                                       (car  alias-alist)
+                                                       (cadr alias-alist)))
+                                          non-conflict
+                                          :initial-value unique-map)))
+               (if (null conflict-set)
+                   updated-map
+                   (rec (mapcar #'car conflict-set)
+                        updated-map
+                        (1+ dir-path-length))))))
+    (rec file-list
+         (fset:empty-map)
+         (if all-conflicts 2 1))))
+
+;; -----------------------------------------------------------------------------
+;; File Naming Helpers
+;; -----------------------------------------------------------------------------
+
+(defun file-name (file &optional (extra-context 1))
+  "takes a file and how much extra context is needed to disambiguate the file
+Returns a string that reconstructs the unique identifier for the file"
+  (let ((name (pathname-name file)))
+    ;; directories have no name!
+    (cond ((not name)
+           (car (last (pathname-directory file))))
+          ((= extra-context 1)
+           name)
+          (t
+           (let* ((disambigous-path   (last (pathname-directory file)
+                                            (1- extra-context)))
+                  (reconstructed-path (butlast (mapcan (lambda (s) (list s "/"))
+                                                       (append disambigous-path
+                                                               (list name))))))
+             (apply #'concatenate 'string reconstructed-path))))))
+
+
+;; -----------------------------------------------------------------------------
+;; Tests
+;; -----------------------------------------------------------------------------
+(consturct-file-alias-map (append (uiop:directory-files "../../holder/")
+                                  (uiop:directory-files "../../holder/Src/")))
+
+(disambiguate-files (list #P"~/Documents/Work/Repo/juvix/holder/Src/Library.hs"
+                          #P"~/Documents/Work/Repo/juvix/holder/Library.hs"
+                          #P"~Documents/Work/Repo/juvix/holder/Libr.hs")
+                    :all-conflicts nil)

--- a/doc/Code/generate.lisp
+++ b/doc/Code/generate.lisp
@@ -79,12 +79,21 @@
 
 
 (defun conflict-map-to-haskell-import (conflict-map)
-  (fset:m))
+  (fset:image (lambda (key value)
+                (values (convert-path key) value))
+              conflict-map))
 
 ;; TODO Parameterize this much better
-(defun convert-path (file &optional (dir-before-lirbary "src"))
-  
-  )
+(defun convert-path (file &optional (dir-before-library "src"))
+  (labels ((last-dir-before (xs)
+             (let ((next (member dir-before-library xs :test #'equal)))
+               (if next
+                   (last-dir-before (cdr next))
+                   xs))))
+    (reconstruct-path (append
+                       (last-dir-before (pathname-directory file))
+                       (list (pathname-name file)))
+                      ".")))
 
 
 ;; -----------------------------------------------------------------------------
@@ -273,3 +282,7 @@ Returns a string that reconstructs the unique identifier for the file"
 (get-directory-info "../../holder/")
 
 (files-and-dirs "../../holder/")
+
+(construct-file-alias-map
+ (lose-dir-information
+  (files-and-dirs "../../holder/src/")))

--- a/doc/Code/generate.lisp
+++ b/doc/Code/generate.lisp
@@ -1,4 +1,6 @@
 (ql:quickload "cl-org-mode")
+(ql:quickload "trivia")
+(ql:quickload "fset")
 
 (asdf:load-system :uiop)
 
@@ -8,8 +10,31 @@
 (in-package :code-generation)
 
 ;; (uiop:directory-files "../../holder/")
+;; Maybe type -----------------------------------------------
+;; todo better type it
+(defconstant +nothing+ :none)
+
+(defstruct just val)
+
+(deftype maybe ()
+    `(or
+      (eql :none)
+      (satisfies just-p)))
+
+;; Directory and file types ---------------------------------
+(defstruct org-directory
+  ;; some directories have a file that re-export things
+  (file +nothing+ :type maybe)
+  ;; a dir consists of either a file-info-p or a org-directory-p
+  (dir  nil       :type list))
+
+(defstruct file-info
+  (path  ""        :type pathname)
+  (alias +nothing+ :type maybe))
+
 
 (defun generate-org-file (directory)
+  ;; (labels ((rec (directory conflicts))))
   (let ((files    (uiop:directory-files directory))
         (sub-dirs (uiop:subdirectories directory)))
     ))

--- a/scripts/generate.lisp
+++ b/scripts/generate.lisp
@@ -3,7 +3,8 @@
   (asdf:load-system :uiop))
 
 (defpackage #:code-generation
-  (:use #:common-lisp))
+  (:use #:common-lisp)
+  (:export :generate-org-file))
 
 (in-package :code-generation)
 

--- a/scripts/run-generate.lisp
+++ b/scripts/run-generate.lisp
@@ -1,0 +1,12 @@
+#!/bin/sbcl --script
+
+(let ((quicklisp-init (merge-pathnames "quicklisp/setup.lisp"
+                                       (user-homedir-pathname))))
+  (when (probe-file quicklisp-init)
+    (load quicklisp-init)))
+
+(load "./generate.lisp")
+
+(code-generation:generate-org-file "../src/" #p"../doc/Code/Juvix.org")
+(code-generation:generate-org-file "../app/" #p"../doc/Code/App.org")
+(code-generation:generate-org-file "../test/" #p"../doc/Code/Test.org")


### PR DESCRIPTION
This PR seeks to fully automate our `code.org` file.

The goal is to use CL to scrape haskell information and create all the needed info.

This will also ential adding the existing documentation to the existing files which was agreed upon in the issue below. 

See #176 for further discussion on the issue.  