### PR TITLE
Thealmarty/fix usage eq instance

### DIFF
--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -7,6 +7,6 @@ make format
 # disabled for now
 # make lint
 
-cd scripts && ./run-generate.lisp
+cd ~/scripts && ./run-generate.lisp
 
 exit 0

--- a/src/Juvix/Core/Erasure/Algorithm.hs
+++ b/src/Juvix/Core/Erasure/Algorithm.hs
@@ -47,9 +47,9 @@ eraseTerm ∷
   Core.Term primTy primVal →
   m (Erased.Term primVal, Erased.Type primTy)
 eraseTerm parameterisation term usage ty =
-  case usage of
-    Core.SNat 0 → throw @"erasureError" (CannotEraseZeroUsageTerm (show (term, usage, ty)))
-    _ → case term of
+  if usage == Core.SNat 0
+    then throw @"erasureError" (CannotEraseZeroUsageTerm (show (term, usage, ty)))
+    else case term of
       Core.Star _ → throw @"erasureError" Unsupported
       Core.PrimTy _ → throw @"erasureError" Unsupported
       Core.Pi _ _ _ → throw @"erasureError" Unsupported

--- a/src/Juvix/Core/Usage.hs
+++ b/src/Juvix/Core/Usage.hs
@@ -20,8 +20,8 @@ instance Show NatAndw where
 
 instance Eq NatAndw where
   SNat x == SNat y = x == y
-  SNat _ == Omega = True
-  Omega == _ = True
+  Omega == _ = False
+  SNat x == Omega = True
 
 -- Addition is the semi-Ring/Monoid instance
 instance Semigroup NatAndw where


### PR DESCRIPTION
- new `Eq` instance as per #191 tests fail still to be investigated. 
- change the Erasure code to use equality instead of case comparison - @cwgoes could you please do the check you were doing again to see check that the behaviour of this new `Eq` instance is desired.  