### PR TITLE
macOS patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,22 @@ The following are required:
 - **Stack**
   - For Ubuntu/Debian : `apt install stack`
   - For Arch Linux    : `pacman -S stack`
+  - For macOS : `brew install haskell-stack`
 - **Z3**
   - `make build-z3` while in the `juvix` directory
 - **libsecp256k1**
   - For Ubuntu/Debian : `apt install libsecp256k1-dev`
   - For Arch Linux : `pacman -S libsecp256k1`
+  - For macOS : `brew tap cuber/homebrew-libsecp256k1 && brew install libsecp256k1`
 - **Openssl Libssl API**
   - For Ubuntu/Debian : `apt install libssl-dev`
   - For Arch Linux : `pacman -S openssl`
+  - For macOS : `brew install openssl`
 - **LLVM9**
   - For Arch Linux : `pacman -S llvm`
+  - For macOS : it requires the latest xcode, then `brew install
+    llvm-hs/llvm/llvm-9`,  if it crashes due to “unknown xcode version”, run
+    `sudo xcode-select -r`. For newly installed xcode, you will need to accept Apple’s terms and conditions.
 
 ### Building
 

--- a/package.yaml
+++ b/package.yaml
@@ -36,7 +36,6 @@ dependencies:
   - time
   - morley
   - bulletproofs
-  - hevm
   - elliptic-curve
   - sonic
   - aeson

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 - .
 
 extra-deps:
-- llvm-hs-9.0.0
+- llvm-hs-9.0.1
 - llvm-hs-pure-9.0.0
 - constraints-0.11
 - singletons-2.5.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,10 +48,6 @@ extra-deps:
   commit: e23b58b46affb978c17a0eb3e760d28b058658ce
 - github: cryptiumlabs/jsonschema-gen
   commit: 0639cd166ec59a04d07a3a7d49bdf343e567000e
-- github: dapphub/dapptools
-  commit: 5f6812169f99a71d12d21229f410238c4c2af964
-  subdirs:
-    - src/hevm
 - github: adjoint-io/pairing
   commit: 2ef8ba869608432f55e32afc385b7fa75d4d1742
 - github: adjoint-io/elliptic-curve

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: llvm-hs-9.0.0@sha256:b036b8d3a78607310382f82b7c5303ffc31afb9735875bb64521501144cc5728,8700
+    hackage: llvm-hs-9.0.1@sha256:ee6ec2eb8cba4daf2a43586388a87dbfd6a2ec6d81d1f9965896ac187acad286,8700
     pantry-tree:
       size: 13599
-      sha256: d572dd639dd315c94eccdfd9b10a3c266163cf945778141087a003c1ed836a91
+      sha256: 537616dec1351bd9f7905182f82f132359cf3058ebbb059c03b4edcef04b2689
   original:
-    hackage: llvm-hs-9.0.0
+    hackage: llvm-hs-9.0.1
 - completed:
     hackage: llvm-hs-pure-9.0.0@sha256:134779f40086a366279f678e670b610d7a7618b28dd43f65894078fd20e04629,2945
     pantry-tree:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -313,22 +313,6 @@ packages:
   original:
     url: https://github.com/cryptiumlabs/jsonschema-gen/archive/0639cd166ec59a04d07a3a7d49bdf343e567000e.tar.gz
 - completed:
-    size: 363229
-    subdir: src/hevm
-    url: https://github.com/dapphub/dapptools/archive/5f6812169f99a71d12d21229f410238c4c2af964.tar.gz
-    cabal-file:
-      size: 6306
-      sha256: 8729cfbcd4bbf4c392f75efdd0b54bcdee2b785b761197e2b053bd6bc72c55f8
-    name: hevm
-    version: '0.35'
-    sha256: d0331819e6f362595e69034949b357b87a4863064a89bec354c668c617827da0
-    pantry-tree:
-      size: 3288
-      sha256: 1f783a42855d93c4bd9862824952d32de8eab8c2661aa60ca1fc170aa2bc4c58
-  original:
-    subdir: src/hevm
-    url: https://github.com/dapphub/dapptools/archive/5f6812169f99a71d12d21229f410238c4c2af964.tar.gz
-- completed:
     size: 36625
     url: https://github.com/adjoint-io/pairing/archive/2ef8ba869608432f55e32afc385b7fa75d4d1742.tar.gz
     cabal-file:


### PR DESCRIPTION
This PR:
 - bumps llvm-hs to 9.0.1 that solves issues with clang
 - remove `hevm`
 - add instuctions to `README.md` to build project on macOS