### PR TITLE
Add non-fungible token contract example in Idris.

### DIFF
--- a/experimental/Examples/FakeLib.idr
+++ b/experimental/Examples/FakeLib.idr
@@ -6,6 +6,15 @@ module FakeLib
 Address : Type
 Address = String
 
+||| Error errors
+data Error = NotEnoughBalance
+           | FailedToAuthenticate
+           | NotAllowedToSpendFrom
+           | NotEnoughAllowance
+           | TokenAlreadyMinted
+           | NonExistenceToken
+           | NotOwnedByFromAddress
+
 ||| currentCaller is the address of the caller of the current operation.
 currentCaller : Address
 currentCaller = "qwer"

--- a/experimental/Examples/FakeLib.idr
+++ b/experimental/Examples/FakeLib.idr
@@ -14,6 +14,7 @@ data Error = NotEnoughBalance
            | TokenAlreadyMinted
            | NonExistenceToken
            | NotOwnedByFromAddress
+           | OwnerCannotBeOperator
 
 ||| currentCaller is the address of the caller of the current operation.
 currentCaller : Address

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -18,7 +18,7 @@ record Account where
 record Token where
   constructor MkToken
   tokenOwner : Address
-  approved : Vect n Address -- approved addresses
+  approved : Vect n Address -- approved address(es)
 
 ||| The storage has type Storage which is a record with accounts and tokens.
 record Storage where
@@ -94,12 +94,24 @@ total balanceOf : Address -> Nat
 balanceOf address =
   getAccountBal address (accounts storage)
 
-total ownerOf : TokenId -> Either Error Address
+-- abstract these two functions later
+ownerOf : TokenId -> Either Error Address
 ownerOf token =
   case lookup token (tokens storage) of
     Nothing => Left NonExistenceToken
     Just t => Right (tokenOwner t)
 
+total getApproved : TokenId -> Either Error (Vect {n} Address)
+getApproved token =
+  case lookup token (tokens storage) of
+    Nothing => Left NonExistenceToken
+    Just t => Right (approved t)
+
+{-
+total approve : Address -> TokenId -> Either Error Storage
+approve address token =
+  case currentCaller == ownerOf token ||
+-}
 {-
 
 ||| performTransfer transfers tokens from the from address to the dest address.

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -45,6 +45,8 @@ getAccount address accounts = case lookup address accounts of
                       Nothing => MkAccount 0 empty
                       (Just account) => account
 
+||| getAccountBal returns the balance of an associated key hash.
+||| @address the key hash of the owner of the account
 total getAccountBal : (address : Address) -> SortedMap Address Account -> Nat
 getAccountBal address accounts = case lookup address accounts of
                       Nothing => 0
@@ -86,10 +88,14 @@ total storage : Storage
 storage =
   initStorage
 
+||| balanceOf [standard function]
+||| returns the number of NFTs owned by the input address.
 total balanceOf : Address -> Nat
 balanceOf address =
   getAccountBal address (accounts storage)
 
+||| ownerOf [standard function]
+||| returns the address of the owner of the input NFT.
 ownerOf : TokenId -> Either Error Address
 ownerOf token =
   case lookup token (tokens storage) of
@@ -104,6 +110,8 @@ ownerOfToken token =
     Left e => owner storage
     Right a => a
 
+||| getApproved [standard function]
+||| get the approved address for the input NFT
 total getApproved : TokenId -> Either Error (Maybe Address)
 getApproved token =
   case lookup token (tokens storage) of
@@ -118,7 +126,7 @@ approvedAdd token =
     Left e => Just (owner storage)
     Right a => a
 
-||| approve set the approved address for an NFT.
+||| approve [standard function] set the approved address for an NFT.
 ||| When a transfer executes, the approved
 ||| address for that NFT (if any) is reset to none.
 total approve : Address -> TokenId -> Either Error Storage
@@ -144,13 +152,15 @@ approve address token =
                    } storage
                  )
 
+||| newOp function to update the operator list.
 total newOp : Address -> Bool -> SortedMap Address Bool
 newOp operator isSet =
   case lookup currentCaller (accounts storage) of
     Nothing => insert operator isSet empty
     Just op => insert operator isSet (opApprovals op)
 
-||| setApprovalForAll let the owner enable or disable an operator.
+||| setApprovalForAll [standard function]
+||| let the owner enable or disable an operator.
 ||| The operator can manage all NFTs of the owner.
 total setApprovalForAll : (operator : Address) -> Bool -> Storage
 setApprovalForAll operator isSet =
@@ -165,6 +175,10 @@ setApprovalForAll operator isSet =
         (accounts storage)
       } storage
 
+||| isApprovedForAll [standard function]
+||| returns whether an address is an authorized operator for another address.
+||| @owner the address that owns the NFTs.
+||| @operator the address that acts on behalf of the owner.
 total isApprovedForAll : (owner : Address) -> (operator : Address) -> Bool
 isApprovedForAll owner operator =
   case lookup owner (accounts storage) of
@@ -174,13 +188,15 @@ isApprovedForAll owner operator =
         Nothing => False
         Just bool => bool
 
+||| modifyAccBal function to modify the account balance.
 total modifyAccBal :
 Address -> (Nat -> Nat) -> SortedMap Address Account -> SortedMap Address Account
 modifyAccBal add f acc =
   let addAcc = getAccount add acc in
     insert add (record {ownedTokens $= f} addAcc) acc
 
-||| transfer transfers a NFT from the from address to the dest address.
+||| transfer [standard function] 
+||| transfers the ownership of a NFT from one address to another.
 ||| @from the address the tokens to be transferred from
 ||| @dest the address the tokens to be transferred to
 ||| @token the TokenId of the NFT to be transferred

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -28,11 +28,6 @@ record Storage where
     totalSup : Nat
     owner : Address -- owner of this NFT contract
 
-data Error = FailedToAuthenticate
-           | TokenAlreadyMinted
-           | NonExistenceToken
-           | NotOwnedByFromAddress
-
 total emptyStorage : Storage
 emptyStorage =
   MkStorage
@@ -175,7 +170,7 @@ approve address token =
 
 total isApprovedForAll : (owner : Address) -> (operator : Address) -> Bool
 isApprovedForAll owner operator =
-  
+
 
 ||| transfer transfers a NFT from the from address to the dest address.
 ||| @from the address the tokens to be transferred from

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -1,0 +1,101 @@
+-- Example non-fungible token contract (ERC721) in Idris.
+import Data.SortedMap
+import Data.Vect
+import FakeLib
+
+||| TokenId is the unique identifier for each NFT
+TokenId : Type
+TokenId = Nat
+
+||| Account is a dependent record on the balance (the number of NFT owned)
+||| by an associated address. It contains
+||| a vector of of tokenIds owned and a map of operators approved.
+record Account (bal : Nat) where
+  constructor MkAccount
+  ownedTokens : Vect bal TokenId --vect of tokenIds owned
+  opApprovals : SortedMap Address Bool --operator approvals
+
+||| Token contains the
+record Token where
+  constructor MkToken
+  owner : Address
+  approved : Vect n Address --approved addresses
+
+||| The storage has type Storage which is a record with accounts and tokens.
+record Storage where
+    constructor MkStorage
+    accounts : SortedMap Address (Account bal)
+    tokens : SortedMap TokenId Token
+
+data Error = FailedToAuthenticate
+           | NotAllowedToSpendFrom
+
+initStorage : Storage
+initStorage =
+  MkStorage
+    (insert "qwer" (MkAccount ((++) Nil 1) empty) empty)
+    (insert 1 (MkToken "qwer" Nil) empty)
+{-
+||| getAccount returns the balance of an associated key hash.
+||| @address the key hash of the owner of the balance
+total getAccount : (address : Address) -> SortedMap Address Account -> Account
+getAccount address accounts = case lookup address accounts of
+                      Nothing => MkAccount 0 empty
+                      (Just account) => account
+
+total getAccountBalance : (address : Address) -> SortedMap Address Account -> Nat
+getAccountBalance address accounts = case lookup address accounts of
+                      Nothing => 0
+                      (Just account) => balance account
+
+||| performTransfer transfers tokens from the from address to the dest address.
+||| @from the address the tokens to be transferred from
+||| @dest the address the tokens to be transferred to
+||| @tokens the amount of tokens to be transferred
+||| @storage the current storage
+total performTransfer :
+(from : Address) -> (dest : Address) -> (tokens : Nat) -> (storage : Storage)
+-> Either Error Storage
+performTransfer from dest tokens storage =
+  let fromBalance = getAccountBalance from (accounts storage)
+      destBalance = getAccountBalance dest (accounts storage) in
+        case lte tokens fromBalance of
+             False => Left NotEnoughBalance
+             True =>
+               let accountsStored =
+                 modifyBalance from (minus fromBalance tokens) (accounts storage) in
+                 Right
+                   (record
+                     {accounts =
+                       modifyBalance dest (destBalance + tokens) accountsStored
+                     } storage)
+
+||| approve update the allowance map of the caller of the contract
+||| @spender the address the caller approve the tokens to transfer to
+||| @tokens the amount of tokens approved to be transferred
+||| @storage the current storage
+total approve :
+(spender : Address) -> (tokens : Nat) -> (storage : Storage) -> Storage
+approve spender tokens storage =
+  let caller = owner storage in -- caller of the contract is set to be the owner for now.
+    updateAllowance caller spender tokens storage
+
+||| transferFrom can be called by anyone,
+||| transferring amount no larger than the approved amount
+||| @from the address the tokens to be transferred from
+||| @dest the address the tokens to transfer to
+||| @tokens the amount to be transferred
+||| @storage the current storage
+total transferFrom :
+(from : Address) -> (dest : Address) -> (tokens : Nat) -> (storage : Storage)
+-> Either Error Storage
+transferFrom from dest tokens storage =
+  case lookup dest (getAccountAllowance from (accounts storage)) of
+    Nothing => Left NotAllowedToSpendFrom
+    (Just allowed) =>
+      case lte tokens allowed of
+        False => Left NotEnoughAllowance
+        True =>
+          let updatedStorage = updateAllowance from dest (minus allowed tokens) storage in
+                    performTransfer from dest tokens updatedStorage
+-}

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -33,8 +33,8 @@ data Error = FailedToAuthenticate
            | TokenAlreadyMinted
            | NotAllowedToSpendFrom
 
-initStorage : Storage
-initStorage =
+emptyStorage : Storage
+emptyStorage =
   MkStorage
     empty
     empty
@@ -79,6 +79,13 @@ mint token dest storage =
                          totalSup = (totalSup storage) + 1
                         } storage
                       )
+
+initStorage : Storage
+initStorage =
+  case mint 1 "qwer" emptyStorage of
+    Left _ => emptyStorage
+    Right s => s
+
 {-
 
 ||| performTransfer transfers tokens from the from address to the dest address.

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -60,16 +60,17 @@ getAccountBal address accounts = case lookup address accounts of
 total mint :
 (token : TokenId) -> (dest : Address) -> (storage : Storage) -> Either Error Storage
 mint token dest storage =
-  let acc = accounts storage in
-    let destAcc = getAccount dest acc in
-      case lookup token (tokens storage) of
+  let currentAcc = accounts storage
+      currentTok = tokens storage in
+    let destAcc = getAccount dest currentAcc in
+      case lookup token currentTok of
         Just something => Left TokenAlreadyMinted
         Nothing =>
           case currentCaller == owner storage of
             False => Left FailedToAuthenticate
             True =>
-              let newAcc = insert dest (record {ownedTokens $= (+ 1)} destAcc) acc
-                  newToken = insert token (MkToken dest Nothing) (tokens storage) in
+              let newAcc = insert dest (record {ownedTokens $= (+ 1)} destAcc) currentAcc
+                  newToken = insert token (MkToken dest Nothing) currentTok in
                     Right
                       (record
                         {accounts = newAcc,
@@ -88,17 +89,23 @@ total storage : Storage
 storage =
   initStorage
 
+total currentAcc : SortedMap Address Account
+currentAcc = accounts storage
+
+total currentTok : SortedMap TokenId Token
+currentTok = tokens storage
+
 ||| balanceOf [standard function]
 ||| returns the number of NFTs owned by the input address.
 total balanceOf : Address -> Nat
 balanceOf address =
-  getAccountBal address (accounts storage)
+  getAccountBal address currentAcc
 
 ||| ownerOf [standard function]
 ||| returns the address of the owner of the input NFT.
 ownerOf : TokenId -> Either Error Address
 ownerOf token =
-  case lookup token (tokens storage) of
+  case lookup token currentTok of
     Nothing => Left NonExistenceToken
     Just t => Right (tokenOwner t)
 
@@ -114,7 +121,7 @@ ownerOfToken token =
 ||| get the approved address for the input NFT
 total getApproved : TokenId -> Either Error (Maybe Address)
 getApproved token =
-  case lookup token (tokens storage) of
+  case lookup token currentTok of
     Nothing => Left NonExistenceToken
     Just t => Right (approved t)
 
@@ -148,14 +155,14 @@ approve address token =
                        owner
                        (Just address)
                      )
-                     (tokens storage)
+                     currentTok
                    } storage
                  )
 
 ||| newOp function to update the operator list.
 total newOp : Address -> Bool -> SortedMap Address Bool
 newOp operator isSet =
-  case lookup currentCaller (accounts storage) of
+  case lookup currentCaller currentAcc of
     Nothing => insert operator isSet empty
     Just op => insert operator isSet (opApprovals op)
 
@@ -172,7 +179,7 @@ setApprovalForAll operator isSet =
           (balanceOf currentCaller)
           (newOp operator isSet)
         )
-        (accounts storage)
+        currentAcc
       } storage
 
 ||| isApprovedForAll [standard function]
@@ -181,7 +188,7 @@ setApprovalForAll operator isSet =
 ||| @operator the address that acts on behalf of the owner.
 total isApprovedForAll : (owner : Address) -> (operator : Address) -> Bool
 isApprovedForAll owner operator =
-  case lookup owner (accounts storage) of
+  case lookup owner currentAcc of
     Nothing => False
     Just op =>
       case lookup operator (opApprovals op) of
@@ -195,7 +202,7 @@ modifyAccBal add f acc =
   let addAcc = getAccount add acc in
     insert add (record {ownedTokens $= f} addAcc) acc
 
-||| transfer [standard function] 
+||| transfer [standard function]
 ||| transfers the ownership of a NFT from one address to another.
 ||| @from the address the tokens to be transferred from
 ||| @dest the address the tokens to be transferred to
@@ -214,8 +221,8 @@ transfer from dest token =
                isApprovedForAll add currentCaller of
             False => Left FailedToAuthenticate
             True =>
-              let newAcc = modifyAccBal from (minus 1) (modifyAccBal dest (+ 1) (accounts storage))
-                  newToken = insert token (MkToken dest Nothing) (tokens storage) in
+              let newAcc = modifyAccBal from (minus 1) (modifyAccBal dest (+ 1) currentAcc)
+                  newToken = insert token (MkToken dest Nothing) currentTok in
                 Right
                   (record
                     {accounts = newAcc,

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -7,46 +7,79 @@ import FakeLib
 TokenId : Type
 TokenId = Nat
 
-||| Account is a dependent record on the balance (the number of NFT owned)
-||| by an associated address. It contains
-||| a vector of of tokenIds owned and a map of operators approved.
+||| Account contains the balance (number of tokens owned)
+||| and a map of operator approvals of an associated address.
 record Account where
   constructor MkAccount
-  ownedTokens : Vect bal TokenId --vect of tokenIds owned
+  ownedTokens : Nat
   opApprovals : SortedMap Address Bool --operator approvals
 
-||| Token contains the
+||| Token contains the info of a specific token
 record Token where
   constructor MkToken
   owner : Address
-  approved : Vect n Address --approved addresses
+  approved : Vect n Address -- approved addresses
 
 ||| The storage has type Storage which is a record with accounts and tokens.
 record Storage where
     constructor MkStorage
     accounts : SortedMap Address Account
     tokens : SortedMap TokenId Token
+    version : Nat -- version of the token standard
+    totalSup : Nat
+    owner : Address -- owner of this NFT contract
 
 data Error = FailedToAuthenticate
+           | TokenAlreadyMinted
            | NotAllowedToSpendFrom
 
 initStorage : Storage
 initStorage =
   MkStorage
-    (insert "qwer" (MkAccount Nil empty) empty)
-    (insert 1 (MkToken "qwer" Nil) empty)
-{-
-||| getAccount returns the balance of an associated key hash.
-||| @address the key hash of the owner of the balance
+    empty
+    empty
+    1
+    0
+    "qwer"
+
+||| getAccount returns the account of an associated key hash.
+||| @address the key hash of the owner of the account
 total getAccount : (address : Address) -> SortedMap Address Account -> Account
 getAccount address accounts = case lookup address accounts of
                       Nothing => MkAccount 0 empty
                       (Just account) => account
 
-total getAccountBalance : (address : Address) -> SortedMap Address Account -> Nat
-getAccountBalance address accounts = case lookup address accounts of
+total getAccountBal : (address : Address) -> SortedMap Address Account -> Nat
+getAccountBal address accounts = case lookup address accounts of
                       Nothing => 0
-                      (Just account) => balance account
+                      (Just account) => ownedTokens account
+
+||| mint when the caller is the owner of the token contract,
+||| they can mint/add new tokens to the total supply
+||| @token the token to be added to the total supply
+||| @dest the address the new tokens to be added to
+||| @storage the original storage
+total mint :
+(token : TokenId) -> (dest : Address) -> (storage : Storage) -> Either Error Storage
+mint token dest storage =
+  let acc = accounts storage in
+    let destAcc = getAccount dest acc in
+      case lookup token (tokens storage) of
+        Just something => Left TokenAlreadyMinted
+        Nothing =>
+          case currentCaller == owner storage of
+            False => Left FailedToAuthenticate
+            True =>
+              let newAcc = insert dest (record {ownedTokens = (1 + getAccountBal dest acc)} destAcc) acc
+                  newToken = insert token (MkToken dest Nil) (tokens storage) in
+                    Right
+                      (record
+                        {accounts = newAcc,
+                         tokens = newToken,
+                         totalSup = (totalSup storage) + 1
+                        } storage
+                      )
+{-
 
 ||| performTransfer transfers tokens from the from address to the dest address.
 ||| @from the address the tokens to be transferred from

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -1,6 +1,5 @@
 -- Example non-fungible token contract (ERC721) in Idris.
 import Data.SortedMap
-import Data.Vect
 import FakeLib
 
 ||| TokenId is the unique identifier for each NFT
@@ -18,7 +17,7 @@ record Account where
 record Token where
   constructor MkToken
   tokenOwner : Address
-  approved : Vect n Address -- approved address(es)
+  approved : List Address -- approved address(es)
 
 ||| The storage has type Storage which is a record with accounts and tokens.
 record Storage where
@@ -101,9 +100,9 @@ ownerOf token =
     Nothing => Left NonExistenceToken
     Just t => Right (tokenOwner t)
 
-total getApproved : TokenId -> Either Error (Vect {n} Address)
+total getApproved : TokenId -> Either Error (List Address)
 getApproved token =
-  case lookup token (tokens storage) of
+  case Data.SortedMap.lookup token (tokens storage) of
     Nothing => Left NonExistenceToken
     Just t => Right (approved t)
 

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -17,7 +17,7 @@ record Account where
 ||| Token contains the info of a specific token
 record Token where
   constructor MkToken
-  owner : Address
+  tokenOwner : Address
   approved : Vect n Address -- approved addresses
 
 ||| The storage has type Storage which is a record with accounts and tokens.
@@ -31,9 +31,9 @@ record Storage where
 
 data Error = FailedToAuthenticate
            | TokenAlreadyMinted
-           | NotAllowedToSpendFrom
+           | NonExistenceToken
 
-emptyStorage : Storage
+total emptyStorage : Storage
 emptyStorage =
   MkStorage
     empty
@@ -80,11 +80,25 @@ mint token dest storage =
                         } storage
                       )
 
-initStorage : Storage
+total initStorage : Storage
 initStorage =
   case mint 1 "qwer" emptyStorage of
     Left _ => emptyStorage
     Right s => s
+
+total storage : Storage
+storage =
+  initStorage
+
+total balanceOf : Address -> Nat
+balanceOf address =
+  getAccountBal address (accounts storage)
+
+total ownerOf : TokenId -> Either Error Address
+ownerOf token =
+  case lookup token (tokens storage) of
+    Nothing => Left NonExistenceToken
+    Just t => Right (tokenOwner t)
 
 {-
 

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -118,11 +118,11 @@ getApproved token =
     Nothing => Left NonExistenceToken
     Just t => Right (approved t)
 
-||| approval set the approved address for an NFT.
+||| approve set the approved address for an NFT.
 ||| When a transfer executes, the approved
 ||| address for that NFT (if any) is reset to none.
-total approval : Address -> TokenId -> Either Error Storage
-approval address token =
+total approve : Address -> TokenId -> Either Error Storage
+approve address token =
   case getApproved token of
     Left e => Left e
     Right approvedAdd =>
@@ -151,10 +151,10 @@ approval address token =
 --         Jusy add
 --     } (tokens storage)
 
--- ||| approvalForAll let the owner enable or disable an operator.
+-- ||| setApprovalForAll let the owner enable or disable an operator.
 -- ||| The operator can manage all NFTs of the owner.
--- total approvalForAll : (operator : Address) -> Bool -> Storage
--- approvalForAll operator isSet =
+-- total setApprovalForAll : (operator : Address) -> Bool -> Storage
+-- setApprovalForAll operator isSet =
 --   record
 --     {accounts =
 --       insert
@@ -173,6 +173,10 @@ approval address token =
 --       (accounts storage)
 --     } storage
 
+total isApprovedForAll : (owner : Address) -> (operator : Address) -> Bool
+isApprovedForAll owner operator =
+  
+
 ||| transfer transfers a NFT from the from address to the dest address.
 ||| @from the address the tokens to be transferred from
 ||| @dest the address the tokens to be transferred to
@@ -188,29 +192,9 @@ transfer from dest token =
         True =>
           case currentCaller == from ||
                currentCaller == getApproved token ||
-               currentCaller == ?operator of
+               currentCaller == isApprovedForAll of
             False => Left FailedToAuthenticate
             True =>
               --set dest ownedTokens to $= (+1)
               --set tokenOwner address to dest
               --set approved address to none
-{-
-||| transferFrom can be called by anyone,
-||| transferring amount no larger than the approved amount
-||| @from the address the tokens to be transferred from
-||| @dest the address the tokens to transfer to
-||| @tokens the amount to be transferred
-||| @storage the current storage
-total transferFrom :
-(from : Address) -> (dest : Address) -> (tokens : Nat) -> (storage : Storage)
--> Either Error Storage
-transferFrom from dest tokens storage =
-  case lookup dest (getAccountAllowance from (accounts storage)) of
-    Nothing => Left NotAllowedToSpendFrom
-    (Just allowed) =>
-      case lte tokens allowed of
-        False => Left NotEnoughAllowance
-        True =>
-          let updatedStorage = updateAllowance from dest (minus allowed tokens) storage in
-                    performTransfer from dest tokens updatedStorage
--}

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -169,18 +169,23 @@ newOp operator isSet =
 ||| setApprovalForAll [standard function]
 ||| let the owner enable or disable an operator.
 ||| The operator can manage all NFTs of the owner.
-total setApprovalForAll : (operator : Address) -> Bool -> Storage
+total setApprovalForAll : (operator : Address) -> Bool -> Either Error Storage
 setApprovalForAll operator isSet =
-    record
-      {accounts =
-        insert
-        currentCaller
-        (MkAccount
-          (balanceOf currentCaller)
-          (newOp operator isSet)
-        )
-        currentAcc
-      } storage
+  case currentCaller == operator of
+    True => Left OwnerCannotBeOperator
+    False =>
+      Right
+        (record
+          {accounts =
+            insert
+            currentCaller
+            (MkAccount
+              (balanceOf currentCaller)
+              (newOp operator isSet)
+            )
+            currentAcc
+          } storage
+         )
 
 ||| isApprovedForAll [standard function]
 ||| returns whether an address is an authorized operator for another address.

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -10,7 +10,7 @@ TokenId = Nat
 ||| Account is a dependent record on the balance (the number of NFT owned)
 ||| by an associated address. It contains
 ||| a vector of of tokenIds owned and a map of operators approved.
-record Account (bal : Nat) where
+record Account where
   constructor MkAccount
   ownedTokens : Vect bal TokenId --vect of tokenIds owned
   opApprovals : SortedMap Address Bool --operator approvals
@@ -24,7 +24,7 @@ record Token where
 ||| The storage has type Storage which is a record with accounts and tokens.
 record Storage where
     constructor MkStorage
-    accounts : SortedMap Address (Account bal)
+    accounts : SortedMap Address Account
     tokens : SortedMap TokenId Token
 
 data Error = FailedToAuthenticate
@@ -33,7 +33,7 @@ data Error = FailedToAuthenticate
 initStorage : Storage
 initStorage =
   MkStorage
-    (insert "qwer" (MkAccount ((++) Nil 1) empty) empty)
+    (insert "qwer" (MkAccount Nil empty) empty)
     (insert 1 (MkToken "qwer" Nil) empty)
 {-
 ||| getAccount returns the balance of an associated key hash.

--- a/experimental/Examples/NFT.idr
+++ b/experimental/Examples/NFT.idr
@@ -138,13 +138,6 @@ approve address token =
                      (tokens storage)
                    } storage
                  )
---figuring out nested record update, doesn't work atm
--- newAcc : Address -> Token
--- newAcc add =
---   record
---     {approved -> tokens =
---         Jusy add
---     } (tokens storage)
 
 total newOp : Address -> Bool -> SortedMap Address Bool
 newOp operator isSet =
@@ -167,10 +160,15 @@ setApprovalForAll operator isSet =
         (accounts storage)
       } storage
 
--- total isApprovedForAll : (owner : Address) -> (operator : Address) -> Bool
--- isApprovedForAll owner operator =
+total isApprovedForAll : (owner : Address) -> (operator : Address) -> Bool
+isApprovedForAll owner operator =
+  case lookup owner (accounts storage) of
+    Nothing => False
+    Just op =>
+      case lookup operator (opApprovals op) of
+        Nothing => False
+        Just bool => bool
 
---
 -- ||| transfer transfers a NFT from the from address to the dest address.
 -- ||| @from the address the tokens to be transferred from
 -- ||| @dest the address the tokens to be transferred to

--- a/experimental/Examples/Token.idr
+++ b/experimental/Examples/Token.idr
@@ -34,8 +34,8 @@ storage : Storage
 storage =
   MkStorage (insert "qwer" (MkAccount 1000 empty) empty) 1 1000 "Cool" "C" "qwer"
 
-||| getAccount returns the balance of an associated key hash.
-||| @address the key hash of the owner of the balance
+||| getAccount returns the account of an associated key hash.
+||| @address the key hash of the owner of the account
 total getAccount : (address : Address) -> SortedMap Address Account -> Account
 getAccount address accounts = case lookup address accounts of
                       Nothing => MkAccount 0 empty

--- a/experimental/Examples/Token.idr
+++ b/experimental/Examples/Token.idr
@@ -19,11 +19,6 @@ record Storage where
     symbol : String
     owner : Address
 
-data Error = NotEnoughBalance
-           | FailedToAuthenticate
-           | NotAllowedToSpendFrom
-           | NotEnoughAllowance
-
 initStorage : Storage
 initStorage =
   MkStorage (insert "qwer" (MkAccount 1000 empty) empty) 1 1000 "Cool" "C" "qwer"


### PR DESCRIPTION
In this PR:
- Added NFT contract. All mandatory functions of the ERC 721 standard are there. `Mint` function, which is optional, is added as well. 
- Error type moved to FakeLib.
- Minimally tested. See [test log](https://gist.github.com/thealmarty/f6d7bf62163f4cade457553c2c4baf70). Further tests should be done with more interesting storage's.

Things to consider:
- in the standard, the list of operators is a map of `Address` and `Bool`. Does
  it make sense to just have a `list`/`vect`? Addresses on the list are equivalent
  to `True` in the Address Bool map.
- in the standard, there can at most be one approved address. Does it make sense
  to allow more than one address? This is like the list of operators in
  `Account` except that the list is linked to a specific token instead of a
  specific address.
- should I check in `setApprovalForAll` that the owner address is not in the
  operator list? (Owner always have powers equivalent to an operator.)