### PR TITLE
Deal with names leaving scope in `hrToIR`

### DIFF
--- a/src/Juvix/Core/Translate.hs
+++ b/src/Juvix/Core/Translate.hs
@@ -20,12 +20,10 @@ hrToIR' term =
     HR.PrimTy p -> pure (IR.PrimTy p)
     HR.Pi u n a b -> do
       a <- hrToIR' a
-      pushName n
-      b <- hrToIR' b
+      b <- withName n $ hrToIR' b
       pure (IR.Pi u a b)
     HR.Lam n b -> do
-      pushName n
-      b <- hrToIR' b
+      b <- withName n $ hrToIR' b
       pure (IR.Lam b)
     HR.Elim e -> IR.Elim |<< hrElimToIR' e
 

--- a/src/Juvix/Core/Utility.hs
+++ b/src/Juvix/Core/Utility.hs
@@ -1,12 +1,19 @@
 module Juvix.Core.Utility where
 
-import Data.List (findIndex)
+import Data.List (findIndex, tail, (!!))
 import Juvix.Library
-import Prelude ((!!))
 
 pushName ::
   HasState "symbolStack" [Symbol] m => Symbol -> m ()
 pushName name = modify @"symbolStack" (name :)
+
+popName :: HasState "symbolStack" [Symbol] m => m ()
+popName = modify @"symbolStack" tail
+  -- FIXME some error message if the stack is empty?
+
+withName ::
+  HasState "symbolStack" [Symbol] m => Symbol -> m a -> m a
+withName n act = pushName n *> act <* popName
 
 lookupName ::
   HasState "symbolStack" [Symbol] m => Symbol -> m (Maybe Int)

--- a/test/CoreConv.hs
+++ b/test/CoreConv.hs
@@ -35,7 +35,16 @@ hrToirConversion =
         (IR.Lam (IR.Lam (IR.Elim (IR.Bound 1)))),
       shouldConvertHR
         (HR.Lam "x" (HR.Lam "y" (HR.Elim (HR.Var "y"))))
-        (IR.Lam (IR.Lam (IR.Elim (IR.Bound 0))))
+        (IR.Lam (IR.Lam (IR.Elim (IR.Bound 0)))),
+      shouldConvertHR
+        (HR.Lam "f" $
+          HR.Elim $ HR.Var "f"
+            `HR.App` HR.Lam "x" (HR.Elim $ HR.Var "x")
+            `HR.App` HR.Lam "y" (HR.Elim $ HR.Var "x"))
+        (IR.Lam $
+          IR.Elim $ IR.Bound 0
+            `IR.App` IR.Lam (IR.Elim $ IR.Bound 0)
+            `IR.App` IR.Lam (IR.Elim $ IR.Free (IR.Global "x")))
     ]
 
 irTohrConversion :: T.TestTree


### PR DESCRIPTION
Fixes #357.