### PR TITLE
Clean up the capability instance deriving stuff a little

### DIFF
--- a/src/Juvix/Backends/LLVM/Codegen/Types.hs
+++ b/src/Juvix/Backends/LLVM/Codegen/Types.hs
@@ -70,70 +70,70 @@ data Errors
     BlockLackingTerminator Int
   deriving (Show, Eq)
 
-newtype Codegen a = CodeGen {runCodegen :: ExceptT Errors (State CodegenState) a}
+type CodegenAlias = ExceptT Errors (State CodegenState)
+
+newtype Codegen a = CodeGen {runCodegen :: CodegenAlias a}
   deriving (Functor, Applicative, Monad)
   deriving
     ( HasState "currentBlock" Name,
       HasSink "currentBlock" Name,
       HasSource "currentBlock" Name
     )
-    via Field "currentBlock" () (MonadState (ExceptT Errors (State CodegenState)))
+    via StateField "currentBlock" CodegenAlias
   deriving
     ( HasState "blocks" (Map.T Name BlockState),
       HasSink "blocks" (Map.T Name BlockState),
       HasSource "blocks" (Map.T Name BlockState)
     )
-    via Field "blocks" () (MonadState (ExceptT Errors (State CodegenState)))
+    via StateField "blocks" CodegenAlias
   deriving
     ( HasState "symTab" SymbolTable,
       HasSink "symTab" SymbolTable,
       HasSource "symTab" SymbolTable
     )
-    via Field "symTab" () (MonadState (ExceptT Errors (State CodegenState)))
+    via StateField "symTab" CodegenAlias
   deriving
     ( HasState "varTab" VariantToType,
       HasSink "varTab" VariantToType,
       HasSource "varTab" VariantToType
     )
-    via Field "varTab" () (MonadState (ExceptT Errors (State CodegenState)))
+    via StateField "varTab" CodegenAlias
   deriving
     ( HasState "typTab" TypeTable,
       HasSink "typTab" TypeTable,
       HasSource "typTab" TypeTable
     )
-    via Field "typTab" () (MonadState (ExceptT Errors (State CodegenState)))
+    via StateField "typTab" CodegenAlias
   deriving
     ( HasState "blockCount" Int,
       HasSink "blockCount" Int,
       HasSource "blockCount" Int
     )
-    via Field "blockCount" () (MonadState (ExceptT Errors (State CodegenState)))
+    via StateField "blockCount" CodegenAlias
   deriving
     ( HasState "count" Word,
       HasSink "count" Word,
       HasSource "count" Word
     )
-    via Field "count" () (MonadState (ExceptT Errors (State CodegenState)))
+    via StateField "count" CodegenAlias
   deriving
     ( HasState "names" Names,
       HasSink "names" Names,
       HasSource "names" Names
     )
-    via Field "names" () (MonadState (ExceptT Errors (State CodegenState)))
-  deriving
-    (HasThrow "err" Errors)
-    via MonadError (ExceptT Errors (State CodegenState))
+    via StateField "names" CodegenAlias
   deriving
     ( HasState "moduleAST" AST.Module,
       HasSink "moduleAST" AST.Module,
       HasSource "moduleAST" AST.Module
     )
-    via Field "moduleAST" () (MonadState (ExceptT Errors (State CodegenState)))
+    via StateField "moduleAST" CodegenAlias
   deriving
     ( HasReader "debug" Int,
       HasSource "debug" Int
     )
-    via Field "debug" () (ReadStatePure (MonadState (ExceptT Errors (State CodegenState))))
+    via ReaderField "debug" CodegenAlias
+  deriving (HasThrow "err" Errors) via MonadError CodegenAlias
 
 instance HasState "moduleDefinitions" [Definition] Codegen where
   state_ _ state = do
@@ -158,31 +158,31 @@ newtype LLVM a = LLVM {runLLVM :: State AST.Module a}
       HasSink "moduleName" ShortByteString,
       HasSource "moduleName" ShortByteString
     )
-    via Field "moduleName" () (MonadState (State AST.Module))
+    via StateField "moduleName" (State AST.Module)
   deriving
     ( HasState "moduleSourceFileName" ShortByteString,
       HasSink "moduleSourceFileName" ShortByteString,
       HasSource "moduleSourceFileName" ShortByteString
     )
-    via Field "moduleSourceFileName" () (MonadState (State AST.Module))
+    via StateField "moduleSourceFileName" (State AST.Module)
   deriving
     ( HasState "moduleDataLayout" (Maybe LLVM.AST.DataLayout.DataLayout),
       HasSink "moduleDataLayout" (Maybe LLVM.AST.DataLayout.DataLayout),
       HasSource "moduleDataLayout" (Maybe LLVM.AST.DataLayout.DataLayout)
     )
-    via Field "moduleDataLayout" () (MonadState (State AST.Module))
+    via StateField "moduleDataLayout" (State AST.Module)
   deriving
     ( HasState "moduleTargetTriple" (Maybe ShortByteString),
       HasSink "moduleTargetTriple" (Maybe ShortByteString),
       HasSource "moduleTargetTriple" (Maybe ShortByteString)
     )
-    via Field "moduleTargetTriple" () (MonadState (State AST.Module))
+    via StateField "moduleTargetTriple" (State AST.Module)
   deriving
     ( HasState "moduleDefinitions" [Definition],
       HasSink "moduleDefinitions" [Definition],
       HasSource "moduleDefinitions" [Definition]
     )
-    via Field "moduleDefinitions" () (MonadState (State AST.Module))
+    via StateField "moduleDefinitions" (State AST.Module)
 
 --------------------------------------------------------------------------------
 -- Effect Aliases

--- a/src/Juvix/Backends/LLVM/Net/EAC/MonadEnvironment.hs
+++ b/src/Juvix/Backends/LLVM/Net/EAC/MonadEnvironment.hs
@@ -36,70 +36,72 @@ data EACState
       }
   deriving (Show, Generic)
 
-newtype EAC a = EACGen {runEAC :: ExceptT Errors (State EACState) a}
+type EACAlias = ExceptT Errors (State EACState)
+
+newtype EAC a = EACGen {runEAC :: EACAlias a}
   deriving (Functor, Applicative, Monad)
   deriving
     ( HasState "currentBlock" Name,
       HasSink "currentBlock" Name,
       HasSource "currentBlock" Name
     )
-    via Field "currentBlock" () (MonadState (ExceptT Errors (State EACState)))
+    via StateField "currentBlock" EACAlias
   deriving
     ( HasState "blocks" (Map.T Name BlockState),
       HasSink "blocks" (Map.T Name BlockState),
       HasSource "blocks" (Map.T Name BlockState)
     )
-    via Field "blocks" () (MonadState (ExceptT Errors (State EACState)))
+    via StateField "blocks" EACAlias
   deriving
     ( HasState "symTab" SymbolTable,
       HasSink "symTab" SymbolTable,
       HasSource "symTab" SymbolTable
     )
-    via Field "symTab" () (MonadState (ExceptT Errors (State EACState)))
+    via StateField "symTab" EACAlias
   deriving
     ( HasState "varTab" VariantToType,
       HasSink "varTab" VariantToType,
       HasSource "varTab" VariantToType
     )
-    via Field "varTab" () (MonadState (ExceptT Errors (State EACState)))
+    via StateField "varTab" EACAlias
   deriving
     ( HasState "typTab" TypeTable,
       HasSink "typTab" TypeTable,
       HasSource "typTab" TypeTable
     )
-    via Field "typTab" () (MonadState (ExceptT Errors (State EACState)))
+    via StateField "typTab" EACAlias
   deriving
     ( HasState "blockCount" Int,
       HasSink "blockCount" Int,
       HasSource "blockCount" Int
     )
-    via Field "blockCount" () (MonadState (ExceptT Errors (State EACState)))
+    via StateField "blockCount" EACAlias
   deriving
     ( HasState "count" Word,
       HasSink "count" Word,
       HasSource "count" Word
     )
-    via Field "count" () (MonadState (ExceptT Errors (State EACState)))
+    via StateField "count" EACAlias
   deriving
     ( HasState "names" Names,
       HasSink "names" Names,
       HasSource "names" Names
     )
-    via Field "names" () (MonadState (ExceptT Errors (State EACState)))
+    via StateField "names" EACAlias
   deriving
     (HasThrow "err" Errors)
-    via MonadError (ExceptT Errors (State EACState))
+    via MonadError EACAlias
   deriving
     ( HasState "moduleAST" AST.Module,
       HasSink "moduleAST" AST.Module,
       HasSource "moduleAST" AST.Module
     )
-    via Field "moduleAST" () (MonadState (ExceptT Errors (State EACState)))
+    via StateField "moduleAST" EACAlias
   deriving
     ( HasReader "debug" Int,
       HasSource "debug" Int
     )
-    via Field "debug" () (ReadStatePure (MonadState (ExceptT Errors (State EACState))))
+    via ReaderField "debug" EACAlias
 
 instance HasState "moduleDefinitions" [Definition] EAC where
   state_ _ state = do

--- a/src/Juvix/Core/Erasure/Types.hs
+++ b/src/Juvix/Core/Erasure/Types.hs
@@ -13,36 +13,38 @@ data Env primTy primVal
       }
   deriving (Show, Eq, Generic)
 
+type EnvEraAlias primTy primVal =
+  ExceptT Error (State (Env primTy primVal))
+
 newtype EnvT primTy primVal a
-  = EnvEra (ExceptT Error (State (Env primTy primVal)) a)
+  = EnvEra (EnvEraAlias primTy primVal a)
   deriving (Functor, Applicative, Monad)
   deriving
     ( HasState "typeAssignment" (Erased.TypeAssignment primTy),
       HasSink "typeAssignment" (Erased.TypeAssignment primTy),
       HasSource "typeAssignment" (Erased.TypeAssignment primTy)
     )
-    via Field "typeAssignment" () (MonadState (ExceptT Error (State (Env primTy primVal))))
+    via StateField "typeAssignment" (EnvEraAlias primTy primVal)
   deriving
     (HasState "context" (TC.Context primTy primVal),
       HasSink "context" (TC.Context primTy primVal),
       HasSource "context" (TC.Context primTy primVal)
     )
-    via Field "context" () (MonadState (ExceptT Error (State (Env primTy primVal))))
+    via StateField "context" (EnvEraAlias primTy primVal)
   deriving
     ( HasState "nextName" Int,
       HasSink "nextName" Int,
       HasSource "nextName" Int
     )
-    via Field "nextName" () (MonadState (ExceptT Error (State (Env primTy primVal))))
+    via StateField "nextName" (EnvEraAlias primTy primVal)
   deriving
     ( HasState "nameStack" [Int],
       HasSink "nameStack" [Int],
       HasSource "nameStack" [Int]
     )
-    via Field "nameStack" () (MonadState (ExceptT Error (State (Env primTy primVal))))
-  deriving
-    (HasThrow "erasureError" Error)
-    via MonadError (ExceptT Error (MonadState (State (Env primTy primVal))))
+    via StateField "nameStack" (EnvEraAlias primTy primVal)
+  deriving (HasThrow "erasureError" Error)
+    via MonadError (EnvEraAlias primTy primVal)
 
 data Error
   = Unsupported

--- a/src/Juvix/Core/IR/Typechecker/Env.hs
+++ b/src/Juvix/Core/IR/Typechecker/Env.hs
@@ -15,19 +15,12 @@ type EnvAlias primTy primVal =
 
 newtype EnvTypecheck primTy primVal a = EnvTyp (EnvAlias primTy primVal a)
   deriving (Functor, Applicative, Monad)
-  deriving (HasThrow "typecheckError" (TypecheckError primTy primVal)) via
-    MonadError
-      (ExceptT (TypecheckError primTy primVal)
-        (MonadState (State (EnvCtx primTy primVal))))
+  deriving (HasThrow "typecheckError" (TypecheckError primTy primVal))
+    via MonadError (EnvAlias primTy primVal)
   deriving
     (HasSink "typecheckerLog" [Log primTy primVal],
      HasWriter "typecheckerLog" [Log primTy primVal])
-  via
-    WriterLog
-      (Field "typecheckerLog" ()
-        (MonadState
-          (ExceptT (TypecheckError primTy primVal)
-            (State (EnvCtx primTy primVal)))))
+  via WriterField "typecheckerLog" (EnvAlias primTy primVal)
 
 exec :: EnvTypecheck primTy primVal a
      -> (Either (TypecheckError primTy primVal) a, EnvCtx primTy primVal)

--- a/src/Juvix/Core/Translate.hs
+++ b/src/Juvix/Core/Translate.hs
@@ -112,16 +112,16 @@ newtype EnvElim a = EnvCon (State Env a)
       HasSink "nextName" Int,
       HasSource "nextName" Int
     )
-    via Field "nextName" () (MonadState (State Env))
+    via StateField "nextName" (State Env)
   deriving
     ( HasState "nameStack" [Int],
       HasSink "nameStack" [Int],
       HasSource "nameStack" [Int]
     )
-    via Field "nameStack" () (MonadState (State Env))
+    via StateField "nameStack" (State Env)
   deriving
     ( HasState "symbolStack" [Symbol],
       HasSink "symbolStack" [Symbol],
       HasSource "symbolStack" [Symbol]
     )
-    via Field "symbolStack" () (MonadState (State Env))
+    via StateField "symbolStack" (State Env)

--- a/src/Juvix/Interpreter/InteractionNet/Backends/Env.hs
+++ b/src/Juvix/Interpreter/InteractionNet/Backends/Env.hs
@@ -53,13 +53,13 @@ newtype EnvNetInfo net a = EnvI (State (InfoNet net) a)
       HasSource "info" Info,
       HasState "info" Info
     )
-    via Field "info" () (MonadState (State (InfoNet net)))
+    via StateField "info" (State (InfoNet net))
   deriving
     ( HasSink "net" net,
       HasSource "net" net,
       HasState "net" net
     )
-    via Field "net" () (MonadState (State (InfoNet net)))
+    via StateField "net" (State (InfoNet net))
 
 newtype EnvNetInfoIO net a = EnvIO (StateT (InfoNet net) IO a)
   deriving (Functor, Applicative, Monad, MonadIO)
@@ -68,13 +68,13 @@ newtype EnvNetInfoIO net a = EnvIO (StateT (InfoNet net) IO a)
       HasSource "info" Info,
       HasState "info" Info
     )
-    via Field "info" () (MonadState (StateT (InfoNet net) IO))
+    via StateField "info" (StateT (InfoNet net) IO)
   deriving
     ( HasSink "net" net,
       HasSource "net" net,
       HasState "net" net
     )
-    via Field "net" () (MonadState (StateT (InfoNet net) IO))
+    via StateField "net" (StateT (InfoNet net) IO)
 
 execInfoNet :: EnvNetInfo net a -> InfoNet net -> InfoNet net
 execInfoNet (EnvI m) = execState m

--- a/src/Juvix/Interpreter/InteractionNet/Translation.hs
+++ b/src/Juvix/Interpreter/InteractionNet/Translation.hs
@@ -36,19 +36,19 @@ newtype EnvState net primVal a = EnvS (State (Env net primVal) a)
       HasSink "level" Int,
       HasSource "level" Int
     )
-    via Rename "level" (Field "level" () (MonadState (State (Env net primVal))))
+    via StateField "level" (State (Env net primVal))
   deriving
     ( HasState "free" (Map.T Symbol (Node, PortType)),
       HasSink "free" (Map.T Symbol (Node, PortType)),
       HasSource "free" (Map.T Symbol (Node, PortType))
     )
-    via (Field "free" () (MonadState (State (Env net primVal))))
+    via StateField "free" (State (Env net primVal))
   deriving
     ( HasState "net" (net (AST.Lang primVal)),
       HasSink "net" (net (AST.Lang primVal)),
       HasSource "net" (net (AST.Lang primVal))
     )
-    via Rename "net'" (Field "net'" () (MonadState (State (Env net primVal))))
+    via Rename "net'" (StateField "net'" (State (Env net primVal)))
 
 execEnvState :: Network net => EnvState net primVal a -> Env net primVal -> Env net primVal
 execEnvState (EnvS m) = execState m

--- a/src/Juvix/Library.hs
+++ b/src/Juvix/Library.hs
@@ -38,6 +38,9 @@ module Juvix.Library
     sortOnFlip,
     uncurry3,
     curry3,
+    StateField,
+    ReaderField,
+    WriterField,
   )
 where
 
@@ -168,3 +171,19 @@ curry3 fn a b c = fn (a, b, c)
 
 (...) :: (b -> c) -> (a1 -> a2 -> b) -> a1 -> a2 -> c
 (...) = (.) . (.)
+
+
+-- | Select a field in a state monad, for example:
+--
+-- @
+-- data Foo = Foo {x, y :: 'Int'}
+-- newtype M a = M ('State' 'Foo' a)
+--   deriving ('HasState' \"x\" 'Int') via StateField "x" ('State' 'Foo')
+-- @
+type StateField fld m = Field fld () (MonadState m)
+
+-- | Reader version of 'StateField'.
+type ReaderField fld m = ReadStatePure (StateField fld m)
+
+-- | Writer version of 'StateField'.
+type WriterField fld m = WriterLog (StateField fld m)


### PR DESCRIPTION
- Introduces some aliases `StateField`, `ReaderField` and `WriterField` in `Juvix.Library` for the `ReadState`/`WriterLog`–`Field`–`MonadState` combo in use everywhere
- Extracts the contents of most `newtype`s into a separate definition to avoid having to repeat it in every `deriving` clause