### PR TITLE
work on the parser, improving inconsistentcies

### DIFF
--- a/doc/Frontend/syntax.org
+++ b/doc/Frontend/syntax.org
@@ -120,10 +120,10 @@
                    | <type>
 
   module-signature-helper
-    ::= sig <name>         :                 <expression>
-      | sig <name>         : <type-name> =\> <expression>
-      | sig <name> <usage> :                 <expression>
-      | sig <name> <usage> : <type-name> =\> <expression>
+    ::= sig <name>           :                 <expression>
+      | sig <name>           : <type-name> =\> <expression>
+      | sig <name> <usage-f> :                 <expression>
+      | sig <name> <usage-f> : <type-name> =\> <expression>
 
 
   cond-top ::= \| <expression> = <top-level>*
@@ -168,6 +168,8 @@
               | <expression''>
 
   usage ::= <expression>
+
+  usage-f ::= <constant> | ( <expression> )
 
   record-access ::= <name>.<name>
 

--- a/src/Juvix/Frontend/Lexer.hs
+++ b/src/Juvix/Frontend/Lexer.hs
@@ -84,7 +84,7 @@ validStartSymbol w =
 
 validInfixSymbol :: Word8 -> Bool
 validInfixSymbol w =
-  Unicode.isSymbol (wordToChr w) || w == times || w == dash || w == amper
+  Unicode.isSymbol (wordToChr w) || w == times || w == dash || w == amper || w == colon
 
 validMiddleSymbol :: Word8 -> Bool
 validMiddleSymbol w =

--- a/src/Juvix/Frontend/Parser.hs
+++ b/src/Juvix/Frontend/Parser.hs
@@ -45,7 +45,7 @@ expressionGen' p =
     <|> try p
     <|> Types.ExpRecord <$> expRecord
     <|> Types.Constant <$> constant
-    <|> try (Types.NamedTypeE <$> namedRefine)
+    -- <|> try (Types.NamedTypeE <$> namedRefine)
     <|> Types.Name <$> prefixSymbolDot
     <|> universeSymbol
     <|> parens (expressionGen all'')
@@ -70,6 +70,10 @@ expression' = expressionGen app''
 -- used to remove app from parsing
 expression'' :: Parser Types.Expression
 expression'' = expressionGen do'''
+
+-- used to remove both from parsing
+expression''' :: Parser Types.Expression
+expression''' = expressionGen (fail "")
 
 expression :: Parser Types.Expression
 expression = expressionGen all''
@@ -306,7 +310,7 @@ product :: Parser Types.Product
 product =
   Types.Record <$> record
     <|> skipLiner Lexer.colon *> fmap Types.Arrow expression
-    <|> fmap Types.ADTLike (many expression''SN)
+    <|> fmap Types.ADTLike (many expression'''SN)
 
 record :: Parser Types.Record
 record = do
@@ -324,9 +328,9 @@ nameType = do
   sig <- expression
   pure (Types.NameType sig name)
 
-nameParserColon :: Parser Types.Name
-nameParserColon =
-  nameParserSN <* skip (== Lexer.colon)
+-- nameParserColon :: Parser Types.Name
+-- nameParserColon =
+--   nameParserSN <* skip (== Lexer.colon)
 
 nameParser :: Parser Types.Name
 nameParser =
@@ -337,9 +341,9 @@ nameParser =
 -- Arrow Type parser
 --------------------------------------------------
 
-namedRefine :: Parser Types.NamedType
-namedRefine =
-  Types.NamedType <$> nameParserColonSN <*> expression
+-- namedRefine :: Parser Types.NamedType
+-- namedRefine =
+--   Types.NamedType <$> nameParserColonSN <*> expression
 
 --------------------------------------------------
 -- TypeNameParser and typeRefine Parser
@@ -431,8 +435,8 @@ lam = do
 
 application :: Parser Types.Application
 application = do
-  name <- prefixSymbolDotSN
-  args <- many1H expression''SN
+  name <- spaceLiner (expressionGen' (fail ""))
+  args <- many1H (spaceLiner (expressionGen' (fail "")))
   pure (Types.App name args)
 
 --------------------------------------------------
@@ -666,6 +670,9 @@ expression'SN = spaceLiner expression'
 expression''SN :: Parser Types.Expression
 expression''SN = spaceLiner expression''
 
+expression'''SN :: Parser Types.Expression
+expression'''SN = spaceLiner expression'''
+
 expressionSN :: Parser Types.Expression
 expressionSN = spaceLiner expression
 
@@ -723,8 +730,8 @@ recordS = spacer record
 nameTypeSN :: Parser Types.NameType
 nameTypeSN = spaceLiner nameType
 
-nameParserColonSN :: Parser Types.Name
-nameParserColonSN = spaceLiner nameParserColon
+-- nameParserColonSN :: Parser Types.Name
+-- nameParserColonSN = spaceLiner nameParserColon
 
 nameParserSN :: Parser Types.Name
 nameParserSN = spaceLiner nameParser
@@ -732,8 +739,8 @@ nameParserSN = spaceLiner nameParser
 bindingSN :: Parser Types.Binding
 bindingSN = spaceLiner binding
 
-namedRefineSN :: Parser Types.NamedType
-namedRefineSN = spaceLiner namedRefine
+-- namedRefineSN :: Parser Types.NamedType
+-- namedRefineSN = spaceLiner namedRefine
 
 sumSN :: Parser Types.Sum
 sumSN = spaceLiner sum

--- a/src/Juvix/Frontend/Types.hs
+++ b/src/Juvix/Frontend/Types.hs
@@ -231,6 +231,7 @@ data Expression
   | NamedTypeE NamedType
   | RefinedE TypeRefine
   | UniverseName UniverseExpression
+  | Parened Expression
   deriving (Show)
 
 data ArrowExp

--- a/src/Juvix/Frontend/Types.hs
+++ b/src/Juvix/Frontend/Types.hs
@@ -269,7 +269,7 @@ data Lambda
 
 data Application
   = App
-      { applicationName :: NameSymb,
+      { applicationName :: Expression,
         applicationArgs :: NonEmpty Expression
       }
   deriving (Show)

--- a/test/Frontend.hs
+++ b/test/Frontend.hs
@@ -206,10 +206,10 @@ many1FunctionsParser =
     \(MatchLogic {matchLogicContents = MatchName a, matchLogicNamed = Nothing}),ConcreteA \
     \(MatchLogic {matchLogicContents = MatchName b, matchLogicNamed = Nothing}),ConcreteA \
     \(MatchLogic {matchLogicContents = MatchName c, matchLogicNamed = Nothing})], functionLikeBody \
-    \= Body (Application (App {applicationName = + :| [], applicationArgs = Infix \
+    \= Body (Application (App {applicationName = Name (+ :| []), applicationArgs = Infix \
     \(Inf {infixLeft = Name (a :| []), infixOp = + :| [], infixRight = Name (b :| [])}) :| [Name \
     \(c :| [])]}))})),Function (Func (Like {functionLikedName = bah, functionLikeArgs \
-    \= [], functionLikeBody = Body (Application (App {applicationName = foo :| [], applicationArgs \
+    \= [], functionLikeBody = Body (Application (App {applicationName = Name (foo :| []), applicationArgs \
     \= Constant (Number (Integer' 1)) :| [Constant (Number (Integer' 2)),Constant \
     \(Number (Integer' 3))]}))})),Function (Func (Like {functionLikedName = nah, functionLikeArgs \
     \= [], functionLikeBody = Guard (C (CondExpression {condLogicPred = Infix (Inf \
@@ -226,7 +226,7 @@ many1FunctionsParser =
     \eleven, matchLogicNamed = Nothing}, matchLBody = Constant (Number (Integer' 7))},MatchL \
     \{matchLPattern = MatchLogic {matchLogicContents = MatchName f, matchLogicNamed \
     \= Nothing}, matchLBody = OpenExpr (OpenExpress {moduleOpenExprModuleN = Fails \
-    \:| [], moduleOpenExprExpr = Application (App {applicationName = print :| [], applicationArgs \
+    \:| [], moduleOpenExprExpr = Application (App {applicationName = Name (print :| []), applicationArgs \
     \= Do (Do' (DoBody {doBodyName = Nothing, doBodyExpr = Name (failed :| [])} :| [DoBody \
     \{doBodyName = Nothing, doBodyExpr = Name (fail :| [])}])) :| []})})}]})}))}))]"
 
@@ -325,7 +325,7 @@ sumTypeTest =
     \= D, sumValue = Just (Record (Record' {recordFields = NameType {nameTypeSignature \
     \= Name (Int :| []), nameTypeName = Concrete a} :| [NameType {nameTypeSignature \
     \= Name (Int :| []), nameTypeName = Implicit b}], recordFamilySignature = Just \
-    \(Application (App {applicationName = Foo :| [], applicationArgs = Name (Int \
+    \(Application (App {applicationName = Name (Foo :| []), applicationArgs = Name (Int \
     \:| []) :| [Infix (Inf {infixLeft = Name (Fooy :| []), infixOp = -> :| [], infixRight \
     \= Name (Nada :| [])})]}))}))}])})}"
 
@@ -344,10 +344,10 @@ superArrowCase =
     \[], infixRight = NamedTypeE (NamedType {nameRefineName = Concrete c, namedRefineRefine \
     \= Infix (Inf {infixLeft = Name (B :| []), infixOp = -o :| [], infixRight = Name \
     \(Foo :| [])})})})}), infixOp = -> :| [], infixRight = Application (App {applicationName \
-    \= Foo :| [], applicationArgs = Name (a :| []) :| [Infix (Inf {infixLeft = Name \
+    \= Name (Foo :| []), applicationArgs = Name (a :| []) :| [Infix (Inf {infixLeft = Name \
     \(b :| []), infixOp = -> :| [], infixRight = NamedTypeE (NamedType {nameRefineName \
-    \= Concrete a, namedRefineRefine = Application (App {applicationName = Bah :| \
-    \[], applicationArgs = Name (a :| []) :| [Infix (Inf {infixLeft = Name (c :| \
+    \= Concrete a, namedRefineRefine = Application (App {applicationName = Name (Bah :| \
+    \[]), applicationArgs = Name (a :| []) :| [Infix (Inf {infixLeft = Name (c :| \
     \[]), infixOp = -o :| [], infixRight = Infix (Inf {infixLeft = Name (HAHAHHA \
     \:| []), infixOp = -> :| [], infixRight = Name (foo :| [])})})]})})})]})})"
 
@@ -417,7 +417,7 @@ moduleOpen' =
     \functionLikeBody = Body (ExpRecord (ExpressionRecord {expRecordFields = NonPunned \
     \(a :| []) (Infix (Inf {infixLeft = Name (t :| []), infixOp = + :| [], infixRight \
     \= Constant (Number (Integer' 3))})) :| [NonPunned (b :| []) (Application (App \
-    \{applicationName = expr :| [], applicationArgs = Name (M :| [N,t]) :| []}))]}))}))])}))"
+    \{applicationName = Name (expr :| []), applicationArgs = Name (M :| [N,t]) :| []}))]}))}))])}))"
 
 --------------------------------------------------
 -- typeName tests
@@ -429,7 +429,7 @@ typeNameNoUniverse =
     "typeNameNoUniverse"
     Parser.expression
     "Foo a b c (b -o d) a c u"
-    "Application (App {applicationName = Foo :| [], applicationArgs = Name (a :| \
+    "Application (App {applicationName = Name (Foo :| []), applicationArgs = Name (a :| \
     \[]) :| [Name (b :| []),Name (c :| []),Infix (Inf {infixLeft = Name (b :| []), \
     \infixOp = -o :| [], infixRight = Name (d :| [])}),Name (a :| []),Name (c :| \
     \[]),Name (u :| [])]})"

--- a/test/Frontend.hs
+++ b/test/Frontend.hs
@@ -206,29 +206,28 @@ many1FunctionsParser =
     \(MatchLogic {matchLogicContents = MatchName a, matchLogicNamed = Nothing}),ConcreteA \
     \(MatchLogic {matchLogicContents = MatchName b, matchLogicNamed = Nothing}),ConcreteA \
     \(MatchLogic {matchLogicContents = MatchName c, matchLogicNamed = Nothing})], functionLikeBody \
-    \= Body (Application (App {applicationName = Name (+ :| []), applicationArgs = Infix \
-    \(Inf {infixLeft = Name (a :| []), infixOp = + :| [], infixRight = Name (b :| [])}) :| [Name \
-    \(c :| [])]}))})),Function (Func (Like {functionLikedName = bah, functionLikeArgs \
-    \= [], functionLikeBody = Body (Application (App {applicationName = Name (foo :| []), applicationArgs \
-    \= Constant (Number (Integer' 1)) :| [Constant (Number (Integer' 2)),Constant \
-    \(Number (Integer' 3))]}))})),Function (Func (Like {functionLikedName = nah, functionLikeArgs \
-    \= [], functionLikeBody = Guard (C (CondExpression {condLogicPred = Infix (Inf \
-    \{infixLeft = Name (bah :| []), infixOp = == :| [], infixRight = Constant (Number \
-    \(Integer' 5))}), condLogicBody = Constant (Number (Integer' 7))} :| [CondExpression \
-    \{condLogicPred = Name (else :| []), condLogicBody = Constant (Number (Integer' \
-    \11))}]))})),Function (Func (Like {functionLikedName = test, functionLikeArgs \
-    \= [], functionLikeBody = Body (Let (Let' {letBindings = Bind {bindingPattern \
-    \= MatchLogic {matchLogicContents = MatchName check, matchLogicNamed = Nothing}, \
-    \bindingBody = Name (nah :| [])} :| [], letBody = Match (Match' {matchOn = Name \
-    \(check :| []), matchBindigns = MatchL {matchLPattern = MatchLogic {matchLogicContents \
-    \= MatchName seven, matchLogicNamed = Nothing}, matchLBody = Constant (Number \
-    \(Integer' 11))} :| [MatchL {matchLPattern = MatchLogic {matchLogicContents = MatchName \
-    \eleven, matchLogicNamed = Nothing}, matchLBody = Constant (Number (Integer' 7))},MatchL \
+    \= Body (Application (App {applicationName = Name (+ :| []), applicationArgs = \
+    \Parened (Infix (Inf {infixLeft = Name (a :| []), infixOp = + :| [], infixRight \
+    \= Name (b :| [])})) :| [Name (c :| [])]}))})),Function (Func (Like {functionLikedName \
+    \= bah, functionLikeArgs = [], functionLikeBody = Body (Application (App {applicationName \
+    \= Name (foo :| []), applicationArgs = Constant (Number (Integer' 1)) :| [Constant \
+    \(Number (Integer' 2)),Constant (Number (Integer' 3))]}))})),Function (Func (Like \
+    \{functionLikedName = nah, functionLikeArgs = [], functionLikeBody = Guard (C (CondExpression \
+    \{condLogicPred = Infix (Inf {infixLeft = Name (bah :| []), infixOp = == :| [], \
+    \infixRight = Constant (Number (Integer' 5))}), condLogicBody = Constant (Number \
+    \(Integer' 7))} :| [CondExpression {condLogicPred = Name (else :| []), condLogicBody \
+    \= Constant (Number (Integer' 11))}]))})),Function (Func (Like {functionLikedName \
+    \= test, functionLikeArgs = [], functionLikeBody = Body (Let (Let' {letBindings \
+    \= Bind {bindingPattern = MatchLogic {matchLogicContents = MatchName check, matchLogicNamed \
+    \= Nothing}, bindingBody = Name (nah :| [])} :| [], letBody = Match (Match' {matchOn \
+    \= Name (check :| []), matchBindigns = MatchL {matchLPattern = MatchLogic {matchLogicContents \
+    \= MatchName seven, matchLogicNamed = Nothing}, matchLBody = Constant (Number (Integer' \
+    \11))} :| [MatchL {matchLPattern = MatchLogic {matchLogicContents = MatchName eleven, \
+    \matchLogicNamed = Nothing}, matchLBody = Constant (Number (Integer' 7))},MatchL \
     \{matchLPattern = MatchLogic {matchLogicContents = MatchName f, matchLogicNamed \
     \= Nothing}, matchLBody = OpenExpr (OpenExpress {moduleOpenExprModuleN = Fails \
-    \:| [], moduleOpenExprExpr = Application (App {applicationName = Name (print :| []), applicationArgs \
-    \= Do (Do' (DoBody {doBodyName = Nothing, doBodyExpr = Name (failed :| [])} :| [DoBody \
-    \{doBodyName = Nothing, doBodyExpr = Name (fail :| [])}])) :| []})})}]})}))}))]"
+    \:| [], moduleOpenExprExpr = Application (App {applicationName = Name (print :| \
+    \[]), applicationArgs = Name (failed :| []) :| []})})}]})}))}))]"
 
 --------------------------------------------------------------------------------
 -- Sig Test
@@ -252,13 +251,10 @@ sigTest2 =
     Parser.topLevel
     "sig foo 0 : i : Int{i > 0} -> Int{i > 1}"
     "Signature (Sig {signatureName = foo, signatureUsage = Just (Constant (Number \
-    \(Integer' 0))), signatureArrowType = Infix (Inf {infixLeft = NamedTypeE (NamedType \
-    \{nameRefineName = Concrete i, namedRefineRefine = RefinedE (TypeRefine {typeRefineName \
-    \= Name (Int :| []), typeRefineRefinement = Infix (Inf {infixLeft = Name (i :| \
-    \[]), infixOp = > :| [], infixRight = Constant (Number (Integer' 0))})})}), infixOp \
-    \= -> :| [], infixRight = RefinedE (TypeRefine {typeRefineName = Name (Int :| \
-    \[]), typeRefineRefinement = Infix (Inf {infixLeft = Name (i :| []), infixOp \
-    \= > :| [], infixRight = Constant (Number (Integer' 1))})})}), signatureConstraints \
+    \(Integer' 0))), signatureArrowType = Infix (Inf {infixLeft = Name (i :| []), \
+    \infixOp = : :| [], infixRight = RefinedE (TypeRefine {typeRefineName = Name \
+    \(Int :| []), typeRefineRefinement = Infix (Inf {infixLeft = Name (i :| []), \
+    \infixOp = > :| [], infixRight = Constant (Number (Integer' 0))})})}), signatureConstraints \
     \= []})"
 
 --------------------------------------------------------------------------------
@@ -313,21 +309,21 @@ sumTypeTest =
         <> "            | D { a : Int, #b : Int } : Foo Int (Fooy -> Nada)"
     )
     "Typ {typeUsage = Nothing, typeName = Foo, typeArgs = [a,b,c], typeForm = Data \
-    \(NonArrowed {dataAdt = Sum (S {sumConstructor = A, sumValue = Just (Arrow (NamedTypeE \
-    \(NamedType {nameRefineName = Concrete b, namedRefineRefine = Infix (Inf {infixLeft \
-    \= Infix (Inf {infixLeft = Name (a :| []), infixOp = -> :| [], infixRight = Name \
-    \(b :| [])}), infixOp = -> :| [], infixRight = Name (c :| [])})})))} :| [S {sumConstructor \
-    \= B, sumValue = Just (Arrow (Infix (Inf {infixLeft = Name (d :| []), infixOp \
-    \= -> :| [], infixRight = Name (Foo :| [])})))},S {sumConstructor = C, sumValue \
-    \= Just (Record (Record' {recordFields = NameType {nameTypeSignature = Name (Int \
-    \:| []), nameTypeName = Concrete a} :| [NameType {nameTypeSignature = Name (Int \
-    \:| []), nameTypeName = Implicit b}], recordFamilySignature = Nothing}))},S {sumConstructor \
-    \= D, sumValue = Just (Record (Record' {recordFields = NameType {nameTypeSignature \
+    \(NonArrowed {dataAdt = Sum (S {sumConstructor = A, sumValue = Just (Arrow (Infix \
+    \(Inf {infixLeft = Name (b :| []), infixOp = : :| [], infixRight = Infix (Inf \
+    \{infixLeft = Name (a :| []), infixOp = -> :| [], infixRight = Infix (Inf {infixLeft \
+    \= Name (b :| []), infixOp = -> :| [], infixRight = Name (c :| [])})})})))} :| \
+    \[S {sumConstructor = B, sumValue = Just (Arrow (Infix (Inf {infixLeft = Name \
+    \(d :| []), infixOp = -> :| [], infixRight = Name (Foo :| [])})))},S {sumConstructor \
+    \= C, sumValue = Just (Record (Record' {recordFields = NameType {nameTypeSignature \
     \= Name (Int :| []), nameTypeName = Concrete a} :| [NameType {nameTypeSignature \
-    \= Name (Int :| []), nameTypeName = Implicit b}], recordFamilySignature = Just \
-    \(Application (App {applicationName = Name (Foo :| []), applicationArgs = Name (Int \
-    \:| []) :| [Infix (Inf {infixLeft = Name (Fooy :| []), infixOp = -> :| [], infixRight \
-    \= Name (Nada :| [])})]}))}))}])})}"
+    \= Name (Int :| []), nameTypeName = Implicit b}], recordFamilySignature = Nothing}))},S \
+    \{sumConstructor = D, sumValue = Just (Record (Record' {recordFields = NameType \
+    \{nameTypeSignature = Name (Int :| []), nameTypeName = Concrete a} :| [NameType \
+    \{nameTypeSignature = Name (Int :| []), nameTypeName = Implicit b}], recordFamilySignature \
+    \= Just (Application (App {applicationName = Name (Foo :| []), applicationArgs \
+    \= Name (Int :| []) :| [Parened (Infix (Inf {infixLeft = Name (Fooy :| []), infixOp \
+    \= -> :| [], infixRight = Name (Nada :| [])}))]}))}))}])})}"
 
 --------------------------------------------------
 -- Arrow Testing
@@ -339,17 +335,18 @@ superArrowCase =
     "superArrowCase"
     Parser.expression
     "( b : Bah -> \n c : B -o Foo) -> Foo a b -> a : Bah a c -o ( HAHAHHA -> foo )"
-    "Infix (Inf {infixLeft = NamedTypeE (NamedType {nameRefineName = Concrete b, \
-    \namedRefineRefine = Infix (Inf {infixLeft = Name (Bah :| []), infixOp = -> :| \
-    \[], infixRight = NamedTypeE (NamedType {nameRefineName = Concrete c, namedRefineRefine \
-    \= Infix (Inf {infixLeft = Name (B :| []), infixOp = -o :| [], infixRight = Name \
-    \(Foo :| [])})})})}), infixOp = -> :| [], infixRight = Application (App {applicationName \
-    \= Name (Foo :| []), applicationArgs = Name (a :| []) :| [Infix (Inf {infixLeft = Name \
-    \(b :| []), infixOp = -> :| [], infixRight = NamedTypeE (NamedType {nameRefineName \
-    \= Concrete a, namedRefineRefine = Application (App {applicationName = Name (Bah :| \
-    \[]), applicationArgs = Name (a :| []) :| [Infix (Inf {infixLeft = Name (c :| \
-    \[]), infixOp = -o :| [], infixRight = Infix (Inf {infixLeft = Name (HAHAHHA \
-    \:| []), infixOp = -> :| [], infixRight = Name (foo :| [])})})]})})})]})})"
+    "Infix (Inf {infixLeft = Parened (Infix (Inf {infixLeft = Name (b :| []), infixOp \
+    \= : :| [], infixRight = Infix (Inf {infixLeft = Name (Bah :| []), infixOp = \
+    \-> :| [], infixRight = Infix (Inf {infixLeft = Name (c :| []), infixOp = : :| \
+    \[], infixRight = Infix (Inf {infixLeft = Name (B :| []), infixOp = -o :| [], \
+    \infixRight = Name (Foo :| [])})})})})), infixOp = -> :| [], infixRight = Infix \
+    \(Inf {infixLeft = Application (App {applicationName = Name (Foo :| []), applicationArgs \
+    \= Name (a :| []) :| [Name (b :| [])]}), infixOp = -> :| [], infixRight = Infix \
+    \(Inf {infixLeft = Name (a :| []), infixOp = : :| [], infixRight = Infix (Inf \
+    \{infixLeft = Application (App {applicationName = Name (Bah :| []), applicationArgs \
+    \= Name (a :| []) :| [Name (c :| [])]}), infixOp = -o :| [], infixRight = Parened \
+    \(Infix (Inf {infixLeft = Name (HAHAHHA :| []), infixOp = -> :| [], infixRight \
+    \= Name (foo :| [])}))})})})})"
 
 --------------------------------------------------
 -- alias tests
@@ -404,7 +401,7 @@ moduleOpen' =
         <> "  open M"
         <> "  sig bah : Rec \n"
         <> "  let bah t = \n"
-        <> "     { a = (t + 3)"
+        <> "     { a = t + 3"
         <> "     , b = expr M.N.t}"
         <> "end"
     )
@@ -429,10 +426,10 @@ typeNameNoUniverse =
     "typeNameNoUniverse"
     Parser.expression
     "Foo a b c (b -o d) a c u"
-    "Application (App {applicationName = Name (Foo :| []), applicationArgs = Name (a :| \
-    \[]) :| [Name (b :| []),Name (c :| []),Infix (Inf {infixLeft = Name (b :| []), \
-    \infixOp = -o :| [], infixRight = Name (d :| [])}),Name (a :| []),Name (c :| \
-    \[]),Name (u :| [])]})"
+    "Application (App {applicationName = Name (Foo :| []), applicationArgs = Name \
+    \(a :| []) :| [Name (b :| []),Name (c :| []),Parened (Infix (Inf {infixLeft = \
+    \Name (b :| []), infixOp = -o :| [], infixRight = Name (d :| [])})),Name (a :| \
+    \[]),Name (c :| []),Name (u :| [])]})"
 
 --------------------------------------------------------------------------------
 -- Match tests
@@ -503,9 +500,10 @@ parens1 =
     "parens1"
     Parser.expression
     "(       ( \n(({a, b = 3+5})))\n)"
-    "ExpRecord (ExpressionRecord {expRecordFields = Punned (a :| []) :| [NonPunned \
-    \(b :| []) (Infix (Inf {infixLeft = Constant (Number (Integer' 3)), \
-    \infixOp = + :| [], infixRight = Constant (Number (Integer' 5))}))]})"
+    "Parened (Parened (Parened (Parened (ExpRecord (ExpressionRecord {expRecordFields \
+    \= Punned (a :| []) :| [NonPunned (b :| []) (Infix (Inf {infixLeft = Constant \
+    \(Number (Integer' 3)), infixOp = + :| [], infixRight = Constant (Number (Integer' \
+    \5))}))]})))))"
 
 --------------------------------------------------------------------------------
 -- Spacer tests


### PR DESCRIPTION
TODO ::
    - Turn arrows into assoc right.
    - fixed no SN on refinements
```haskell
λ> parseOnly Parser.expression "cda : a {d}-> b : string"
Right (Infix (Inf {infixLeft = Infix (Inf {infixLeft = Infix (Inf {infixLeft = Name (cda :| []), infixOp = : :| [], infixRight = RefinedE (TypeRefine {typeRefineName = Name (a :| []), typeRefineRefinement = Name (d :| [])})}), infixOp = -> :| [], infixRight = Name (b :| [])}), infixOp = : :| [], infixRight = Name (string :| [])}))
λ> parseOnly Parser.expression "cda : a {d} -> b : string"
Right (Infix (Inf {infixLeft = Name (cda :| []), infixOp = : :| [], infixRight = RefinedE (TypeRefine {typeRefineName = Name (a :| []), typeRefineRefinement = Name (d :| [])})}))
  ````